### PR TITLE
Use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cosmic-core"]
 	path = cosmic-core
-	url = git@github.com:MissionCriticalCloud/cosmic-core.git
+	url = https://github.com/MissionCriticalCloud/cosmic-core.git
 	branch = master


### PR DESCRIPTION
This way, people (and bubbles) who don't have SSH access can clone the repo's using --recursive.
