### PR TITLE
Replaces Cloudstack with Cosmic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# Eclipse project settings
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
   <artifactId>cosmic</artifactId>
   <version>5.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>Apache CloudStack</name>
-  <description>Apache CloudStack is an IaaS (“Infrastructure as a Service”) cloud orchestration platform.</description>
-  <url>http://www.cloudstack.org</url>
+  <name>Cosmic</name>
+  <description>Cosmic is an IaaS (“Infrastructure as a Service”) cloud orchestration platform.</description>
+  <url>http://www.cosmic.cloud</url>
 
   <prerequisites>
     <maven>3.0.4</maven>
@@ -131,7 +131,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <executions>
           <execution>
-            <id>cloudstack-checkstyle</id>
+            <id>cosmic-checkstyle</id>
             <phase>none</phase>
             <inherited>false</inherited>
           </execution>
@@ -153,7 +153,7 @@
           </dependencies>
           <executions>
             <execution>
-              <id>cloudstack-checkstyle</id>
+              <id>cosmic-checkstyle</id>
               <phase>validate</phase>
               <goals>
                 <goal>check</goal>


### PR DESCRIPTION
This PR replaces CloudStack with Cosmic in the Maven module names.
