### PR TITLE
Moves the packaging directory under cosmic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ fabric.properties
 # Eclipse project settings
 .project
 .settings/
+
+# RPM packaging
+dist/

--- a/packaging/centos63/cloud-agent.rc
+++ b/packaging/centos63/cloud-agent.rc
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# chkconfig: 35 99 10
+# description: Cloud Agent
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# WARNING: if this script is changed, then all other initscripts MUST BE changed to match it as well
+
+. /etc/rc.d/init.d/functions
+
+# set environment variables
+
+SHORTNAME=$(basename $0 | sed -e 's/^[SK][0-9][0-9]//')
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+LOGDIR=/var/log/cloudstack/agent
+LOGFILE=${LOGDIR}/agent.log
+PROGNAME="Cloud Agent"
+CLASS="com.cloud.agent.AgentShell"
+JSVC=`which jsvc 2>/dev/null`;
+
+# exit if we don't find jsvc
+if [ -z "$JSVC" ]; then
+    echo no jsvc found in path;
+    exit 1;
+fi
+
+unset OPTIONS
+[ -r /etc/sysconfig/"$SHORTNAME" ] && source /etc/sysconfig/"$SHORTNAME"
+
+# The first existing directory is used for JAVA_HOME (if JAVA_HOME is not defined in $DEFAULT)
+JDK_DIRS="/usr/lib/jvm/jre /usr/lib/jvm/java-7-openjdk /usr/lib/jvm/java-7-openjdk-i386 /usr/lib/jvm/java-7-openjdk-amd64 /usr/lib/jvm/java-6-openjdk /usr/lib/jvm/java-6-openjdk-i386 /usr/lib/jvm/java-6-openjdk-amd64 /usr/lib/jvm/java-6-sun"
+
+for jdir in $JDK_DIRS; do
+    if [ -r "$jdir/bin/java" -a -z "${JAVA_HOME}" ]; then
+        JAVA_HOME="$jdir"
+    fi
+done
+export JAVA_HOME
+
+ACP=`ls /usr/share/cloudstack-agent/lib/*.jar | tr '\n' ':' | sed s'/.$//'`
+PCP=`ls /usr/share/cloudstack-agent/plugins/*.jar 2>/dev/null | tr '\n' ':' | sed s'/.$//'`
+
+# We need to append the JSVC daemon JAR to the classpath
+# AgentShell implements the JSVC daemon methods
+export CLASSPATH="/usr/share/java/commons-daemon.jar:$ACP:$PCP:/etc/cloudstack/agent:/usr/share/cloudstack-common/scripts"
+
+start() {
+    echo -n $"Starting $PROGNAME: "
+    if hostname --fqdn >/dev/null 2>&1 ; then
+        $JSVC -Xms256m -Xmx2048m -cp "$CLASSPATH" -pidfile "$PIDFILE" \
+            -errfile $LOGDIR/cloudstack-agent.err -outfile $LOGDIR/cloudstack-agent.out $CLASS
+        RETVAL=$?
+        echo
+    else
+        failure
+        echo
+        echo The host name does not resolve properly to an IP address.  Cannot start "$PROGNAME". > /dev/stderr
+        RETVAL=9
+    fi
+    [ $RETVAL = 0 ] && touch ${LOCKFILE}
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping $PROGNAME: "
+    $JSVC -pidfile "$PIDFILE" -stop $CLASS
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && rm -f ${LOCKFILE} ${PIDFILE}
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status -p ${PIDFILE} $SHORTNAME
+        RETVAL=$?
+        ;;
+    restart)
+        stop
+        sleep 3
+        start
+        ;;
+    condrestart)
+        if status -p ${PIDFILE} $SHORTNAME >&/dev/null; then
+            stop
+            sleep 3
+            start
+        fi
+        ;;
+    *)
+    echo $"Usage: $SHORTNAME {start|stop|restart|condrestart|status|help}"
+    RETVAL=3
+esac
+
+exit $RETVAL

--- a/packaging/centos63/cloud-ipallocator.rc
+++ b/packaging/centos63/cloud-ipallocator.rc
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# chkconfig: 35 99 10
+# description: Cloud Agent
+
+# WARNING: if this script is changed, then all other initscripts MUST BE changed to match it as well
+
+. /etc/rc.d/init.d/functions
+
+# set environment variables
+
+SHORTNAME="$(basename $(readlink -f $0))"
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+LOGFILE=/var/log/cloudstack/ipallocator/ipallocator.log
+PROGNAME="External IPAllocator"
+
+unset OPTIONS
+[ -r /etc/sysconfig/"$SHORTNAME" ] && source /etc/sysconfig/"$SHORTNAME"
+DAEMONIZE=/usr/bin/cloud-daemonize
+PROG=/usr/bin/cloud-external-ipallocator.py
+OPTIONS=8083
+
+start() {
+        echo -n $"Starting $PROGNAME: "
+	if hostname --fqdn >/dev/null 2>&1 ; then
+		daemon --check=$SHORTNAME --pidfile=${PIDFILE} "$DAEMONIZE" \
+			-n "$SHORTNAME" -p "$PIDFILE" -l "$LOGFILE" "$PROG" $OPTIONS
+		RETVAL=$?
+		echo
+	else
+		failure
+		echo
+		echo The host name does not resolve properly to an IP address.  Cannot start "$PROGNAME". > /dev/stderr
+		RETVAL=9
+	fi
+	[ $RETVAL = 0 ] && touch ${LOCKFILE}
+	return $RETVAL
+}
+
+stop() {
+	echo -n $"Stopping $PROGNAME: "
+	killproc -p ${PIDFILE} $SHORTNAME # -d 10 $SHORTNAME
+	RETVAL=$?
+	echo
+	[ $RETVAL = 0 ] && rm -f ${LOCKFILE} ${PIDFILE}
+}
+
+
+# See how we were called.
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  status)
+        status -p ${PIDFILE} $SHORTNAME
+	RETVAL=$?
+	;;
+  restart)
+	stop
+	sleep 3
+	start
+	;;
+  condrestart)
+	if status -p ${PIDFILE} $SHORTNAME >&/dev/null; then
+		stop
+		sleep 3
+		start
+	fi
+	;;
+  *)
+	echo $"Usage: $SHORTNAME {start|stop|restart|condrestart|status|help}"
+	RETVAL=3
+esac
+
+exit $RETVAL
+

--- a/packaging/centos63/cloud-management.rc
+++ b/packaging/centos63/cloud-management.rc
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# cloudstack-management      This shell script takes care of starting and stopping Tomcat
+#
+# chkconfig: - 80 20
+#
+### BEGIN INIT INFO
+# Provides: tomcat6
+# Required-Start: $network $syslog
+# Required-Stop: $network $syslog
+# Default-Start:
+# Default-Stop:
+# Description: Release implementation for Servlet 2.5 and JSP 2.1
+# Short-Description: start and stop tomcat
+### END INIT INFO
+#
+# - originally written by Henri Gomez, Keith Irwin, and Nicolas Mailhot
+# - heavily rewritten by Deepak Bhole and Jason Corley
+#
+
+if [ -r /etc/rc.d/init.d/functions ]; then
+    . /etc/rc.d/init.d/functions
+fi
+if [ -r /lib/lsb/init-functions ]; then
+    . /lib/lsb/init-functions
+fi
+
+
+NAME="$(basename $(readlink -f $0))"
+export SERVICE_NAME="$NAME"
+stop() {
+	SHUTDOWN_WAIT="30"
+	count="0"
+	if [ -f /var/run/${NAME}.pid ]; then
+		pid=`cat /var/run/${NAME}.pid`
+		kill $pid &>/dev/null
+		until [ "$(ps --pid $pid | grep -c $pid)" -eq "0" ] || \
+			[ "$count" -gt "$SHUTDOWN_WAIT" ]
+		do
+			sleep 1
+			let count="${count}+1"
+		done
+		if [ "$(ps --pid $pid | grep -c $pid)" -eq "0" ]; then
+			log_success_msg "Stopping ${NAME}:"
+			rm -f /var/run/${NAME}.pid
+			rm -f /var/lock/subsys/${NAME}
+		else
+			log_failure_msg "Stopping ${NAME}:"
+		fi
+	else
+		echo "Cannot find PID file of ${NAME}"
+		log_failure_msg "Stopping ${NAME}:"
+	fi
+}
+
+set_ulimit() {
+    fd_limit=`ulimit -n`
+    if [ "$fd_limit" != "4096" ]; then
+        user=`whoami`
+        if [ $user == "root" ]; then
+            ulimit -n 4096
+        fi
+    fi
+}
+
+handle_pid_file() {
+     if [ "$1" -ne 0 ] && [ "$1" -ne 3 ]; then
+        echo "The pid file locates at /var/run/${NAME}.pid and lock file at /var/lock/subsys/${NAME}.
+        Starting ${NAME} will take care of them or you can manually clean up."
+    fi
+}
+
+start() {
+    readpath=$(readlink -f $0)
+    source `dirname $readpath`/tomcat.sh
+}
+
+# See how we were called.
+case "$1" in
+    status)
+		status ${NAME}
+		RETVAL=$?
+        handle_pid_file $RETVAL
+		;;
+    stop)
+		stop
+		;;
+    restart)
+		stop
+		set start
+        set_ulimit
+	        start
+		;;
+	*)
+        set_ulimit
+                start
+esac
+
+exit $RETVAL

--- a/packaging/centos63/cloud-management.sysconfig
+++ b/packaging/centos63/cloud-management.sysconfig
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This file is loaded in /etc/init.d/vmopsmanagement
+# ATM we only do two things here:
+
+dummy=1 ; export TOMCAT_CFG=/etc/cloudstack/management/tomcat6.conf ; . /etc/cloudstack/management/tomcat6.conf
+#--------------------------
+

--- a/packaging/centos63/cloud-usage.rc
+++ b/packaging/centos63/cloud-usage.rc
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+### BEGIN INIT INFO
+# Provides:          cloudstack-usage
+# Required-Start:    $network $local_fs
+# Required-Stop:     $network $local_fs
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Start/stop Apache CloudStack Usage Monitor
+# Description: This scripts Starts/Stops the Apache CloudStack Usage Monitor
+##  The CloudStack Usage Monitor is a part of the Apache CloudStack project and is used
+##  for storing usage statistics from instances.
+## JSVC (Java daemonizing) is used for starting and stopping the usage monitor.
+### END INIT INFO
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+. /etc/rc.d/init.d/functions
+
+SHORTNAME="cloudstack-usage"
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+LOGDIR=/var/log/cloudstack/usage
+LOGFILE=${LOGDIR}/usage.log
+PROGNAME="CloudStack Usage Monitor"
+CLASS="com.cloud.usage.UsageServer"
+PROG="jsvc"
+DAEMON="/usr/bin/jsvc"
+USER=cloud
+
+unset OPTIONS
+[ -r /etc/sysconfig/default/"$SHORTNAME" ] && source /etc/sysconfig/default/"$SHORTNAME"
+
+setJavaHome() {
+  # use $JAVA_HOME if defined
+  if [ -n "$JAVA_HOME" ] ; then
+    return
+  fi
+
+  # try java first
+  java=$(which java 2>/dev/null || :)
+
+  # try javac if java is not found
+  if [ -z "$java" ] ; then
+    java=$(which javac 2>/dev/null || :)
+  fi
+
+  if [ -n "$java" ] ; then
+    JAVA_HOME=$(dirname $(dirname $(readlink -e $java)))
+    export JAVA_HOME
+    return
+  fi
+
+  # didnt find java home. exiting with error
+  exit 1
+}
+
+setJavaHome
+
+SCP=""
+DCP=""
+UCP=`ls /usr/share/cloudstack-usage/cloud-usage-*.jar`":"`ls /usr/share/cloudstack-usage/lib/*.jar | tr '\n' ':'`
+JCP="/usr/share/java/commons-daemon.jar":"/usr/share/java/mysql-connector-java.jar"
+
+# We need to append the JSVC daemon  and mysql-connector JAR to the classpath
+# AgentShell implements the JSVC daemon methods
+export CLASSPATH="$SCP:$DCP:$UCP:$JCP:/etc/cloudstack/usage"
+
+start() {
+    if [ -s "$PIDFILE" ] && kill -0 $(cat "$PIDFILE") >/dev/null 2>&1; then
+        echo "$PROGNAME apparently already running"
+        exit 0
+    fi
+
+    if hostname --fqdn >/dev/null 2>&1 ; then
+        true
+    else
+        echo "The host name does not resolve properly to an IP address. Cannot start $PROGNAME"
+        exit 1
+    fi
+
+    echo -n "Starting $PROGNAME" "$SHORTNAME"
+
+    if daemon --pidfile $PIDFILE $DAEMON -home "$JAVA_HOME" -cp "$CLASSPATH" -pidfile "$PIDFILE" -user "$USER" \
+      -errfile $LOGDIR/cloudstack-usage.err -outfile $LOGDIR/cloudstack-usage.out -Dpid=$$ $CLASS
+        RETVAL=$?
+    then
+        rc=0
+        sleep 1
+        if ! kill -0 $(cat "$PIDFILE") >/dev/null 2>&1; then
+            failure
+            rc=1
+        fi
+    else
+        rc=1
+    fi
+
+    if [ $rc -eq 0 ]; then
+        success
+    else
+        failure
+        rm -f "$PIDFILE"
+    fi
+    echo
+}
+
+stop() {
+    echo -n "Stopping $PROGNAME" "$SHORTNAME"
+    killproc -p $PIDFILE $DAEMON
+    if [ "$?" -eq 0 ]; then
+        success
+    else
+        failure
+    fi
+    rm -f "$PIDFILE"
+    echo
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status -p $PIDFILE $SHORTNAME
+        RETVAL=$?
+        ;;
+    restart | force-reload)
+        stop
+        sleep 3
+        start
+        ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|force-reload|status}"
+    RETVAL=3
+esac
+
+exit $RETVAL
+

--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -1,0 +1,650 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+%define __os_install_post %{nil}
+%global debug_package %{nil}
+
+# DISABLE the post-percentinstall java repacking and line number stripping
+# we need to find a way to just disable the java repacking and line number stripping, but not the autodeps
+
+Name:      cloudstack
+Summary:   CloudStack IaaS Platform
+#http://fedoraproject.org/wiki/PackageNamingGuidelines#Pre-Release_packages
+%if "%{?_prerelease}" != ""
+%define _maventag %{_ver}-SNAPSHOT
+Release:   %{_rel}%{dist}
+%else
+%define _maventag %{_ver}
+Release:   %{_rel}%{dist}
+%endif
+
+%{!?python_sitearch: %define python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
+
+Version:   %{_ver}
+License:   ASL 2.0
+Vendor:    Apache CloudStack <dev@cloudstack.apache.org>
+Packager:  Apache CloudStack <dev@cloudstack.apache.org>
+Group:     System Environment/Libraries
+# FIXME do groups for every single one of the subpackages
+Source0:   %{name}-%{_maventag}.tgz
+BuildRoot: %{_tmppath}/%{name}-%{_maventag}-%{release}-build
+
+BuildRequires: java-1.7.0-openjdk-devel
+BuildRequires: tomcat6
+BuildRequires: ws-commons-util
+BuildRequires: jpackage-utils
+BuildRequires: gcc
+BuildRequires: glibc-devel
+BuildRequires: /usr/bin/mkisofs
+BuildRequires: MySQL-python
+#BuildRequires: maven => 3.0.0
+
+%description
+CloudStack is a highly-scalable elastic, open source,
+intelligent IaaS cloud implementation.
+
+%package management
+Summary:   CloudStack management server UI
+Requires: tomcat6
+Requires: java-1.7.0-openjdk
+Requires: python
+Requires: bash
+Requires: bzip2
+Requires: gzip
+Requires: unzip
+Requires: /sbin/mount.nfs
+Requires: openssh-clients
+Requires: nfs-utils
+Requires: wget
+Requires: mysql
+Requires: mysql-connector-java
+Requires: ws-commons-util
+Requires: jpackage-utils
+Requires: sudo
+Requires: /sbin/service
+Requires: /sbin/chkconfig
+Requires: /usr/bin/ssh-keygen
+Requires: mkisofs
+Requires: MySQL-python
+Requires: python-paramiko
+Requires: ipmitool
+Requires: %{name}-common = %{_ver}
+Obsoletes: cloud-client < 4.1.0
+Obsoletes: cloud-client-ui < 4.1.0
+Obsoletes: cloud-server < 4.1.0
+Obsoletes: cloud-test < 4.1.0
+Provides:  cloud-client
+Group:     System Environment/Libraries
+%description management
+The CloudStack management server is the central point of coordination,
+management, and intelligence in CloudStack.  
+
+%package common
+Summary: Apache CloudStack common files and scripts
+Requires: python
+Obsoletes: cloud-test < 4.1.0 
+Obsoletes: cloud-scripts < 4.1.0
+Obsoletes: cloud-utils < 4.1.0
+Obsoletes: cloud-core < 4.1.0
+Obsoletes: cloud-deps < 4.1.0
+Obsoletes: cloud-python < 4.1.0
+Obsoletes: cloud-setup < 4.1.0
+Obsoletes: cloud-cli < 4.1.0
+Obsoletes: cloud-daemonize < 4.1.0
+Group:   System Environment/Libraries
+%description common
+The Apache CloudStack files shared between agent and management server
+
+%package agent
+Summary: CloudStack Agent for KVM hypervisors
+Requires: openssh-clients
+Requires: java-1.7.0-openjdk
+Requires: %{name}-common = %{_ver}
+Requires: libvirt
+Requires: bridge-utils
+Requires: ebtables
+Requires: iptables
+Requires: ethtool
+Requires: vconfig
+Requires: ipset
+Requires: jsvc
+Requires: jakarta-commons-daemon
+Requires: jakarta-commons-daemon-jsvc
+Requires: net-tools
+Requires: perl
+Requires: libvirt-python
+Requires: qemu-img
+Requires: qemu-kvm
+Provides: cloud-agent
+Obsoletes: cloud-agent < 4.1.0
+Obsoletes: cloud-agent-libs < 4.1.0
+Obsoletes: cloud-test < 4.1.0
+Group: System Environment/Libraries
+%description agent
+The CloudStack agent for KVM hypervisors
+
+%package baremetal-agent
+Summary: CloudStack baremetal agent
+Requires: tftp-server
+Requires: xinetd
+Requires: syslinux
+Requires: chkconfig
+Requires: dhcp
+Requires: httpd
+Group:     System Environment/Libraries
+%description baremetal-agent
+The CloudStack baremetal agent
+
+%package usage
+Summary: CloudStack Usage calculation server
+Requires: java-1.7.0-openjdk
+Requires: jsvc
+Requires: jakarta-commons-daemon
+Requires: jakarta-commons-daemon-jsvc
+Group: System Environment/Libraries
+Obsoletes: cloud-usage < 4.1.0
+Provides: cloud-usage 
+%description usage
+The CloudStack usage calculation service
+
+%package cli
+Summary: Apache CloudStack CLI
+Provides: python-cloudmonkey
+Provides: python-marvin
+Group: System Environment/Libraries
+%description cli
+Apache CloudStack command line interface
+
+%if "%{_ossnoss}" == "noredist"
+%package mysql-ha
+Summary: Apache CloudStack Balancing Strategy for MySQL
+Requires: mysql-connector-java
+Requires: tomcat6
+Group: System Environmnet/Libraries
+%description mysql-ha
+Apache CloudStack Balancing Strategy for MySQL
+
+%endif
+
+%prep
+echo Doing CloudStack build
+
+%setup -q -n %{name}-%{_maventag}
+
+%build
+
+cp packaging/centos63/replace.properties build/replace.properties
+echo VERSION=%{_maventag} >> build/replace.properties
+echo PACKAGE=%{name} >> build/replace.properties
+touch build/gitrev.txt
+echo $(git rev-parse HEAD) > build/gitrev.txt
+
+if [ "%{_ossnoss}" == "NOREDIST" -o "%{_ossnoss}" == "noredist" ] ; then
+   echo "Executing mvn packaging with non-redistributable libraries"
+   if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then 
+      echo "Executing mvn noredist packaging with simulator ..."
+      mvn -Psystemvm -Dnoredist -Dsimulator clean package
+   else
+      echo "Executing mvn noredist packaging without simulator..."
+      mvn -Psystemvm -Dnoredist clean package
+   fi
+else
+   if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then 
+      echo "Executing mvn default packaging simulator ..."
+      mvn -Psystemvm -Dsimulator clean package
+   else
+      echo "Executing mvn default packaging without simulator ..."
+      mvn -Psystemvm clean package
+   fi
+fi 
+
+%install
+[ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
+# Common directories
+mkdir -p ${RPM_BUILD_ROOT}%{_bindir}
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/ipallocator
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
+mkdir -p ${RPM_BUILD_ROOT}%{_initrddir}
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/sysconfig
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/profile.d
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d
+
+# Common
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms
+mkdir -p ${RPM_BUILD_ROOT}%{python_sitearch}/
+mkdir -p ${RPM_BUILD_ROOT}%/usr/bin
+cp -r scripts/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+install -D systemvm/dist/systemvm.iso ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms/systemvm.iso
+install -D systemvm/dist/systemvm.zip ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms/systemvm.zip
+install python/lib/cloud_utils.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloud_utils.py
+cp -r python/lib/cloudutils ${RPM_BUILD_ROOT}%{python_sitearch}/
+python -m py_compile ${RPM_BUILD_ROOT}%{python_sitearch}/cloud_utils.py
+python -m compileall ${RPM_BUILD_ROOT}%{python_sitearch}/cloudutils
+cp build/gitrev.txt ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+cp packaging/centos63/cloudstack-sccs ${RPM_BUILD_ROOT}/usr/bin
+ 
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts/network/cisco
+cp -r plugins/network-elements/cisco-vnmc/scripts/network/cisco/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts/network/cisco
+
+# Management
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management
+
+# Specific for tomcat
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+ln -sf /usr/share/tomcat6/bin ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/bin
+ln -sf /etc/%{name}/management ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/conf
+ln -sf /usr/share/tomcat6/lib ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/lib
+ln -sf /var/log/%{name}/management ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/logs
+ln -sf /var/cache/%{name}/management/temp ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/temp
+ln -sf /var/cache/%{name}/management/work ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/work
+
+/bin/touch ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management/catalina.out
+
+install -D client/target/utilities/bin/cloud-migrate-databases ${RPM_BUILD_ROOT}%{_bindir}/%{name}-migrate-databases
+install -D client/target/utilities/bin/cloud-set-guest-password ${RPM_BUILD_ROOT}%{_bindir}/%{name}-set-guest-password
+install -D client/target/utilities/bin/cloud-set-guest-sshkey ${RPM_BUILD_ROOT}%{_bindir}/%{name}-set-guest-sshkey
+install -D client/target/utilities/bin/cloud-setup-databases ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-databases
+install -D client/target/utilities/bin/cloud-setup-encryption ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-encryption
+install -D client/target/utilities/bin/cloud-setup-management ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-management
+install -D client/target/utilities/bin/cloud-setup-baremetal ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-baremetal
+install -D client/target/utilities/bin/cloud-sysvmadm ${RPM_BUILD_ROOT}%{_bindir}/%{name}-sysvmadm
+install -D client/target/utilities/bin/cloud-update-xenserver-licenses ${RPM_BUILD_ROOT}%{_bindir}/%{name}-update-xenserver-licenses
+
+cp -r client/target/utilities/scripts/db/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup
+cp -r client/target/cloud-client-ui-%{_maventag}/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client
+
+# Don't package the scripts in the management webapp
+rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/scripts
+rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/vms
+
+for name in db.properties log4j-cloud.xml tomcat6-nonssl.conf tomcat6-ssl.conf server-ssl.xml server-nonssl.xml commons-logging.properties \
+            catalina.policy catalina.properties classpath.conf tomcat-users.xml web.xml environment.properties java.security.ciphers; do
+  mv ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/$name \
+    ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/$name
+done
+
+ln -s %{_sysconfdir}/%{name}/management/log4j-cloud.xml \
+    ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/log4j-cloud.xml
+
+mv ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/context.xml \
+    ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+
+install python/bindir/cloud-external-ipallocator.py ${RPM_BUILD_ROOT}%{_bindir}/%{name}-external-ipallocator.py
+install -D client/target/pythonlibs/jasypt-1.9.2.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/lib/jasypt-1.9.2.jar
+
+install -D packaging/centos63/cloud-ipallocator.rc ${RPM_BUILD_ROOT}%{_initrddir}/%{name}-ipallocator
+install -D packaging/centos63/cloud-management.rc ${RPM_BUILD_ROOT}%{_initrddir}/%{name}-management
+install -D packaging/centos63/cloud-management.sysconfig ${RPM_BUILD_ROOT}%{_sysconfdir}/sysconfig/%{name}-management
+install -D server/target/conf/cloudstack-sudoers ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
+install -D packaging/centos63/tomcat.sh ${RPM_BUILD_ROOT}%{_initrddir}/tomcat.sh
+
+chmod 440 ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+
+# KVM Agent
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/plugins
+install -D packaging/centos63/cloud-agent.rc ${RPM_BUILD_ROOT}%{_sysconfdir}/init.d/%{name}-agent
+install -D agent/target/transformed/agent.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/agent.properties
+install -D agent/target/transformed/environment.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/environment.properties
+install -D agent/target/transformed/log4j-cloud.xml ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/log4j-cloud.xml
+install -D agent/target/transformed/cloud-setup-agent ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-agent
+install -D agent/target/transformed/cloudstack-agent-upgrade ${RPM_BUILD_ROOT}%{_bindir}/%{name}-agent-upgrade
+install -D agent/target/transformed/libvirtqemuhook ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib/libvirtqemuhook
+install -D agent/target/transformed/cloud-ssh ${RPM_BUILD_ROOT}%{_bindir}/%{name}-ssh
+install -D agent/target/transformed/cloudstack-agent-profile.sh ${RPM_BUILD_ROOT}%{_sysconfdir}/profile.d/%{name}-agent-profile.sh
+install -D agent/target/transformed/cloudstack-agent.logrotate ${RPM_BUILD_ROOT}%{_sysconfdir}/logrotate.d/%{name}-agent
+install -D plugins/hypervisors/kvm/target/cloud-plugin-hypervisor-kvm-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%name-agent/lib/cloud-plugin-hypervisor-kvm-%{_maventag}.jar
+cp plugins/hypervisors/kvm/target/dependencies/*  ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib
+
+# Usage server
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib
+install -D usage/target/cloud-usage-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/cloud-usage-%{_maventag}.jar
+install -D usage/target/transformed/db.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage/db.properties
+install -D usage/target/transformed/log4j-cloud_usage.xml ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage/log4j-cloud.xml
+cp usage/target/dependencies/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib/
+install -D packaging/centos63/cloud-usage.rc ${RPM_BUILD_ROOT}/%{_sysconfdir}/init.d/%{name}-usage
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/usage/
+
+# CLI
+cp -r cloud-cli/cloudtool ${RPM_BUILD_ROOT}%{python_sitearch}/
+install cloud-cli/cloudapis/cloud.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloudapis.py
+
+# MYSQL HA
+if [ "x%{_ossnoss}" == "xnoredist" ] ; then
+  mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-mysql-ha/lib
+  cp -r plugins/database/mysql-ha/target/cloud-plugin-database-mysqlha-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-mysql-ha/lib
+fi
+
+#License files from whisker
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-management-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-management-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-common-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-common-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-agent-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-agent-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-cli-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-cli-%{version}/LICENSE
+if [ "x%{_ossnoss}" == "xnoredist" ] ; then
+  install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-mysql-ha-%{version}/LICENSE
+  install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-mysql-ha-%{version}/NOTICE
+fi
+
+%clean
+[ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
+
+%preun management
+/sbin/service cloudstack-management stop || true
+if [ "$1" == "0" ] ; then
+    /sbin/chkconfig --del cloudstack-management  > /dev/null 2>&1 || true
+    /sbin/service cloudstack-management stop > /dev/null 2>&1 || true
+fi
+
+%pre management
+id cloud > /dev/null 2>&1 || /usr/sbin/useradd -M -c "CloudStack unprivileged user" \
+     -r -s /bin/sh -d %{_localstatedir}/cloudstack/management cloud|| true
+
+# set max file descriptors for cloud user to 4096
+sed -i /"cloud hard nofile"/d /etc/security/limits.conf
+sed -i /"cloud soft nofile"/d /etc/security/limits.conf
+echo "cloud hard nofile 4096" >> /etc/security/limits.conf
+echo "cloud soft nofile 4096" >> /etc/security/limits.conf
+rm -rf %{_localstatedir}/cache/cloud
+rm -rf %{_localstatedir}/cache/cloudstack
+# user harcoded here, also hardcoded on wscript
+
+# save old configs if they exist (for upgrade). Otherwise we may lose them
+# when the old packages are erased. There are a lot of properties files here.
+if [ -d "%{_sysconfdir}/cloud" ] ; then
+    mv %{_sysconfdir}/cloud %{_sysconfdir}/cloud.rpmsave
+fi
+
+%post management
+if [ "$1" == "1" ] ; then
+    /sbin/chkconfig --add cloudstack-management > /dev/null 2>&1 || true
+    /sbin/chkconfig --level 345 cloudstack-management on > /dev/null 2>&1 || true
+fi
+
+if [ ! -f %{_datadir}/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util ] ; then
+    echo Please download vhd-util from http://download.cloud.com.s3.amazonaws.com/tools/vhd-util and put it in 
+    echo %{_datadir}/cloudstack-common/scripts/vm/hypervisor/xenserver/
+fi
+
+# change cloud user's home to 4.1+ version if needed. Would do this via 'usermod', but it
+# requires that cloud user not be in use, so RPM could not be installed while management is running
+if getent passwd cloud | grep -q /var/lib/cloud; then 
+    sed -i 's/\/var\/lib\/cloud\/management/\/var\/cloudstack\/management/g' /etc/passwd
+fi
+
+# if saved configs from upgrade exist, copy them over
+if [ -f "%{_sysconfdir}/cloud.rpmsave/management/db.properties" ]; then
+    mv %{_sysconfdir}/%{name}/management/db.properties %{_sysconfdir}/%{name}/management/db.properties.rpmnew
+    cp -p %{_sysconfdir}/cloud.rpmsave/management/db.properties %{_sysconfdir}/%{name}/management
+    if [ -f "%{_sysconfdir}/cloud.rpmsave/management/key" ]; then    
+        cp -p %{_sysconfdir}/cloud.rpmsave/management/key %{_sysconfdir}/%{name}/management
+    fi
+    # make sure we only do this on the first install of this RPM, don't want to overwrite on a reinstall
+    mv %{_sysconfdir}/cloud.rpmsave/management/db.properties %{_sysconfdir}/cloud.rpmsave/management/db.properties.rpmsave
+fi
+
+# Choose server.xml and tomcat.conf links based on old config, if exists
+serverxml=%{_sysconfdir}/%{name}/management/server.xml
+oldserverxml=%{_sysconfdir}/cloud.rpmsave/management/server.xml
+if [ -f $oldserverxml ] || [ -L $oldserverxml ]; then
+    if stat -c %N $oldserverxml| grep -q server-ssl ; then
+        if [ -f $serverxml ] || [ -L $serverxml ]; then rm -f $serverxml; fi
+        ln -s %{_sysconfdir}/%{name}/management/server-ssl.xml $serverxml
+        echo Please verify the server.xml in saved folder, and make the required changes manually , saved folder available at $oldserverxml
+    else
+        if [ -f $serverxml ] || [ -L $serverxml ]; then rm -f $serverxml; fi
+        ln -s %{_sysconfdir}/%{name}/management/server-nonssl.xml $serverxml
+        echo Please verify the server.xml in saved folder, and make the required changes manually , saved folder available at $oldserverxml
+
+    fi
+else
+    echo "Unable to determine ssl settings for server.xml, please run cloudstack-setup-management manually"
+fi
+
+
+tomcatconf=%{_sysconfdir}/%{name}/management/tomcat6.conf
+oldtomcatconf=%{_sysconfdir}/cloud.rpmsave/management/tomcat6.conf
+if [ -f $oldtomcatconf ] || [ -L $oldtomcatconf ] ; then
+    if stat -c %N $oldtomcatconf| grep -q tomcat6-ssl ; then
+        if [ -f $tomcatconf ] || [ -L $tomcatconf ]; then rm -f $tomcatconf; fi
+        ln -s %{_sysconfdir}/%{name}/management/tomcat6-ssl.conf $tomcatconf
+        echo Please verify the tomcat6.conf in saved folder, and make the required changes manually , saved folder available at $oldtomcatconf
+    else
+        if [ -f $tomcatconf ] || [ -L $tomcatconf ]; then rm -f $tomcatconf; fi
+        ln -s %{_sysconfdir}/%{name}/management/tomcat6-nonssl.conf $tomcatconf
+        echo Please verify the tomcat6.conf in saved folder, and make the required changes manually , saved folder available at $oldtomcatconf
+    fi
+else
+    echo "Unable to determine ssl settings for tomcat.conf, please run cloudstack-setup-management manually"
+fi
+
+if [ -f "%{_sysconfdir}/cloud.rpmsave/management/cloud.keystore" ]; then
+    cp -p %{_sysconfdir}/cloud.rpmsave/management/cloud.keystore %{_sysconfdir}/%{name}/management/cloudmanagementserver.keystore
+    # make sure we only do this on the first install of this RPM, don't want to overwrite on a reinstall
+    mv %{_sysconfdir}/cloud.rpmsave/management/cloud.keystore %{_sysconfdir}/cloud.rpmsave/management/cloud.keystore.rpmsave
+fi
+
+%preun agent
+/sbin/service cloudstack-agent stop || true
+if [ "$1" == "0" ] ; then
+    /sbin/chkconfig --del cloudstack-agent > /dev/null 2>&1 || true
+    /sbin/service cloudstack-agent stop > /dev/null 2>&1 || true
+fi
+
+%pre agent
+
+# save old configs if they exist (for upgrade). Otherwise we may lose them
+# when the old packages are erased. There are a lot of properties files here.
+if [ -d "%{_sysconfdir}/cloud" ] ; then
+    mv %{_sysconfdir}/cloud %{_sysconfdir}/cloud.rpmsave
+fi
+
+%post agent
+if [ "$1" == "1" ] ; then
+    echo "Running %{_bindir}/%{name}-agent-upgrade to update bridge name for upgrade from CloudStack 4.0.x (and before) to CloudStack 4.1 (and later)"
+    %{_bindir}/%{name}-agent-upgrade
+    if [ ! -d %{_sysconfdir}/libvirt/hooks ] ; then
+        mkdir %{_sysconfdir}/libvirt/hooks
+    fi
+    cp -a ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib/libvirtqemuhook %{_sysconfdir}/libvirt/hooks/qemu
+    /sbin/service libvirtd restart
+    /sbin/chkconfig --add cloudstack-agent > /dev/null 2>&1 || true
+    /sbin/chkconfig --level 345 cloudstack-agent on > /dev/null 2>&1 || true
+fi
+
+# if saved configs from upgrade exist, copy them over
+if [ -f "%{_sysconfdir}/cloud.rpmsave/agent/agent.properties" ]; then
+    mv %{_sysconfdir}/%{name}/agent/agent.properties  %{_sysconfdir}/%{name}/agent/agent.properties.rpmnew
+    cp -p %{_sysconfdir}/cloud.rpmsave/agent/agent.properties %{_sysconfdir}/%{name}/agent
+    # make sure we only do this on the first install of this RPM, don't want to overwrite on a reinstall
+    mv %{_sysconfdir}/cloud.rpmsave/agent/agent.properties %{_sysconfdir}/cloud.rpmsave/agent/agent.properties.rpmsave
+fi
+
+%preun usage
+/sbin/service cloudstack-usage stop || true
+if [ "$1" == "0" ] ; then
+    /sbin/chkconfig --del cloudstack-usage > /dev/null 2>&1 || true
+    /sbin/service cloudstack-usage stop > /dev/null 2>&1 || true
+fi
+
+%post usage
+if [ -f "%{_sysconfdir}/%{name}/management/db.properties" ]; then
+    echo Replacing db.properties with management server db.properties
+    rm -f %{_sysconfdir}/%{name}/usage/db.properties
+    ln -s %{_sysconfdir}/%{name}/management/db.properties %{_sysconfdir}/%{name}/usage/db.properties
+    /sbin/chkconfig --add cloudstack-usage > /dev/null 2>&1 || true
+    /sbin/chkconfig --level 345 cloudstack-usage on > /dev/null 2>&1 || true
+fi
+
+if [ -f "%{_sysconfdir}/%{name}/management/key" ]; then
+    echo Replacing key with management server key
+    rm -f %{_sysconfdir}/%{name}/usage/key
+    ln -s %{_sysconfdir}/%{name}/management/key %{_sysconfdir}/%{name}/usage/key
+fi
+
+#No default permission as the permission setup is complex
+%files management
+%defattr(-,root,root,-)
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina/localhost
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina/localhost/client
+%dir %{_datadir}/%{name}-management
+%dir %attr(0770,root,cloud) %{_localstatedir}/%{name}/mnt
+%dir %attr(0770,cloud,cloud) %{_localstatedir}/%{name}/management
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/work
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/temp
+%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/management
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}-management
+%config(noreplace) %{_sysconfdir}/sudoers.d/%{name}-management
+%config(noreplace) %attr(0640,root,cloud) %{_sysconfdir}/%{name}/management/db.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/log4j-cloud.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/tomcat6-nonssl.conf
+%config(noreplace) %{_sysconfdir}/%{name}/management/tomcat6-ssl.conf
+%config(noreplace) %{_sysconfdir}/%{name}/management/Catalina/localhost/client/context.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/catalina.policy
+%config(noreplace) %{_sysconfdir}/%{name}/management/catalina.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/classpath.conf
+%config(noreplace) %{_sysconfdir}/%{name}/management/server-nonssl.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/server-ssl.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/tomcat-users.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/web.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/environment.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/java.security.ciphers
+%config(noreplace) %{_sysconfdir}/%{name}/management/commons-logging.properties
+%attr(0755,root,root) %{_initrddir}/%{name}-management
+%attr(0755,root,root) %{_initrddir}/tomcat.sh
+
+%attr(0755,root,root) %{_bindir}/%{name}-setup-management
+%attr(0755,root,root) %{_bindir}/%{name}-update-xenserver-licenses
+%{_datadir}/%{name}-management/webapps
+%{_datadir}/%{name}-management/bin
+%{_datadir}/%{name}-management/conf
+%{_datadir}/%{name}-management/lib
+%{_datadir}/%{name}-management/logs
+%{_datadir}/%{name}-management/temp
+%{_datadir}/%{name}-management/work
+%attr(0755,root,root) %{_bindir}/%{name}-setup-databases
+%attr(0755,root,root) %{_bindir}/%{name}-migrate-databases
+%attr(0755,root,root) %{_bindir}/%{name}-set-guest-password
+%attr(0755,root,root) %{_bindir}/%{name}-set-guest-sshkey
+%attr(0755,root,root) %{_bindir}/%{name}-sysvmadm
+%attr(0755,root,root) %{_bindir}/%{name}-setup-encryption
+%{_datadir}/%{name}-management/setup/*.sql
+%{_datadir}/%{name}-management/setup/db/*.sql
+%{_datadir}/%{name}-management/setup/*.sh
+%{_datadir}/%{name}-management/setup/server-setup.xml
+%attr(0755,root,root) %{_bindir}/%{name}-external-ipallocator.py
+%attr(0755,root,root) %{_initrddir}/%{name}-ipallocator
+%dir %attr(0770,root,root) %{_localstatedir}/log/%{name}/ipallocator
+%{_defaultdocdir}/%{name}-management-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-management-%{version}/NOTICE
+%attr(0644,cloud,cloud) %{_localstatedir}/log/%{name}/management/catalina.out
+
+%files agent
+%attr(0755,root,root) %{_bindir}/%{name}-setup-agent
+%attr(0755,root,root) %{_bindir}/%{name}-agent-upgrade
+%attr(0755,root,root) %{_bindir}/%{name}-ssh
+%attr(0755,root,root) %{_sysconfdir}/init.d/%{name}-agent
+%attr(0644,root,root) %{_sysconfdir}/profile.d/%{name}-agent-profile.sh
+%attr(0644,root,root) %{_sysconfdir}/logrotate.d/%{name}-agent
+%attr(0755,root,root) %{_datadir}/%{name}-common/scripts/network/cisco
+%config(noreplace) %{_sysconfdir}/%{name}/agent
+%dir %{_localstatedir}/log/%{name}/agent
+%attr(0644,root,root) %{_datadir}/%{name}-agent/lib/*.jar
+%attr(0755,root,root) %{_datadir}/%{name}-agent/lib/libvirtqemuhook
+%dir %{_datadir}/%{name}-agent/plugins
+%{_defaultdocdir}/%{name}-agent-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-agent-%{version}/NOTICE
+
+%files common
+%dir %attr(0755,root,root) %{python_sitearch}/cloudutils
+%dir %attr(0755,root,root) %{_datadir}/%{name}-common/vms
+%attr(0755,root,root) %{_datadir}/%{name}-common/scripts
+%attr(0755,root,root) /usr/bin/cloudstack-sccs
+%attr(0644, root, root) %{_datadir}/%{name}-common/vms/systemvm.iso
+%attr(0644, root, root) %{_datadir}/%{name}-common/vms/systemvm.zip
+%attr(0644,root,root) %{python_sitearch}/cloud_utils.py
+%attr(0644,root,root) %{python_sitearch}/cloud_utils.pyc
+%attr(0644,root,root) %{python_sitearch}/cloudutils/*
+%attr(0644, root, root) %{_datadir}/%{name}-common/lib/jasypt-1.9.2.jar
+%{_defaultdocdir}/%{name}-common-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-common-%{version}/NOTICE
+
+%files usage
+%attr(0755,root,root) %{_sysconfdir}/init.d/%{name}-usage
+%attr(0644,root,root) %{_datadir}/%{name}-usage/*.jar
+%attr(0644,root,root) %{_datadir}/%{name}-usage/lib/*.jar
+%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/usage
+%attr(0644,root,root) %{_sysconfdir}/%{name}/usage/db.properties
+%attr(0644,root,root) %{_sysconfdir}/%{name}/usage/log4j-cloud.xml
+%{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+
+%files cli
+%attr(0644,root,root) %{python_sitearch}/cloudapis.py
+%attr(0644,root,root) %{python_sitearch}/cloudtool/__init__.py
+%attr(0644,root,root) %{python_sitearch}/cloudtool/utils.py
+%{_defaultdocdir}/%{name}-cli-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-cli-%{version}/NOTICE
+
+%if "%{_ossnoss}" == "noredist"
+%files mysql-ha
+%defattr(0644,cloud,cloud,0755)
+%attr(0644,root,root) %{_datadir}/%{name}-mysql-ha/lib/*
+%{_defaultdocdir}/%{name}-mysql-ha-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-mysql-ha-%{version}/NOTICE
+%endif
+
+%files baremetal-agent
+%attr(0755,root,root) %{_bindir}/cloudstack-setup-baremetal
+
+%changelog
+* Thu Apr 30 2015 Rohit Yadav <bhaisaab@apache.org> 4.6.0
+- Remove awsapi package
+
+* Fri Jul 04 2014 Hugo Trippaers <hugo@apache.org> 4.5.0
+- Add a package for the mysql ha module
+
+* Wed Oct 03 2012 Hugo Trippaers <hugo@apache.org> 4.1.0
+- new style spec file

--- a/packaging/centos63/cloudstack-agent.te
+++ b/packaging/centos63/cloudstack-agent.te
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module cloudstack-agent 1.0;
+
+require {
+	type nfs_t;
+	type system_conf_t;
+	type mount_t;
+	type qemu_t;
+	class file unlink;
+	class filesystem getattr;
+}
+
+#============= mount_t ==============
+allow mount_t system_conf_t:file unlink;
+
+#============= qemu_t ==============
+allow qemu_t nfs_t:filesystem getattr;

--- a/packaging/centos63/cloudstack-sccs
+++ b/packaging/centos63/cloudstack-sccs
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cat /usr/share/cloudstack-common/scripts/gitrev.txt

--- a/packaging/centos63/replace.properties
+++ b/packaging/centos63/replace.properties
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DBUSER=cloud
+DBPW=cloud
+DBROOTPW=
+MSLOG=vmops.log
+APISERVERLOG=api.log
+DBHOST=localhost
+COMPONENTS-SPEC=components-premium.xml
+REMOTEHOST=localhost
+AGENTCLASSPATH=
+AGENTLOG=/var/log/cloudstack/agent/agent.log
+AGENTLOGDIR=/var/log/cloudstack/agent/
+AGENTSYSCONFDIR=/etc/cloudstack/agent
+APISERVERLOG=/var/log/cloudstack/management/apilog.log
+BINDIR=/usr/bin
+COMMONLIBDIR=/usr/share/cloudstack-common
+CONFIGUREVARS=
+DEPSCLASSPATH=
+DOCDIR=
+IPALOCATORLOG=/var/log/cloudstack/management/ipallocator.log
+JAVADIR=/usr/share/java
+LIBEXECDIR=/usr/libexec
+LOCKDIR=/var/lock
+MSCLASSPATH=
+MSCONF=/etc/cloudstack/management
+MSENVIRON=/usr/share/cloudstack-management
+MSLOG=/var/log/cloudstack/management/management-server.log
+MSLOGDIR=/var/log/cloudstack/management/
+MSMNTDIR=/var/cloudstack/mnt
+MSUSER=cloud
+PIDDIR=/var/run
+PLUGINJAVADIR=/usr/share/cloudstack-management/plugin
+PREMIUMJAVADIR=/usr/share/cloudstack-management/premium
+PYTHONDIR=/usr/lib/python2.6/site-packages/
+SERVERSYSCONFDIR=/etc/sysconfig
+SETUPDATADIR=/usr/share/cloudstack-management/setup
+SYSCONFDIR=/etc/sysconfig
+SYSTEMCLASSPATH=
+SYSTEMJARS=
+USAGECLASSPATH=
+USAGELOG=/var/log/cloudstack/usage/usage.log
+USAGESYSCONFDIR=/etc/sysconfig

--- a/packaging/centos63/rhel7/cloudstack-management.conf
+++ b/packaging/centos63/rhel7/cloudstack-management.conf
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+f /var/run/cloudstack-management.pid 0644 cloud cloud -

--- a/packaging/centos63/tomcat.sh
+++ b/packaging/centos63/tomcat.sh
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+. /etc/rc.d/init.d/tomcat6 start

--- a/packaging/centos7/cloud-agent.rc
+++ b/packaging/centos7/cloud-agent.rc
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# chkconfig: 35 99 10
+# description: Cloud Agent
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# WARNING: if this script is changed, then all other initscripts MUST BE changed to match it as well
+
+. /etc/rc.d/init.d/functions
+
+# set environment variables
+
+SHORTNAME=$(basename $0 | sed -e 's/^[SK][0-9][0-9]//')
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+LOGDIR=/var/log/cloudstack/agent
+LOGFILE=${LOGDIR}/agent.log
+PROGNAME="Cloud Agent"
+CLASS="com.cloud.agent.AgentShell"
+JSVC=`which jsvc 2>/dev/null`;
+
+# exit if we don't find jsvc
+if [ -z "$JSVC" ]; then
+    echo no jsvc found in path;
+    exit 1;
+fi
+
+unset OPTIONS
+[ -r /etc/sysconfig/"$SHORTNAME" ] && source /etc/sysconfig/"$SHORTNAME"
+
+# The first existing directory is used for JAVA_HOME (if JAVA_HOME is not defined in $DEFAULT)
+JDK_DIRS="/usr/lib/jvm/jre /usr/lib/jvm/java-7-openjdk /usr/lib/jvm/java-7-openjdk-i386 /usr/lib/jvm/java-7-openjdk-amd64 /usr/lib/jvm/java-6-openjdk /usr/lib/jvm/java-6-openjdk-i386 /usr/lib/jvm/java-6-openjdk-amd64 /usr/lib/jvm/java-6-sun"
+
+for jdir in $JDK_DIRS; do
+    if [ -r "$jdir/bin/java" -a -z "${JAVA_HOME}" ]; then
+        JAVA_HOME="$jdir"
+    fi
+done
+export JAVA_HOME
+
+ACP=`ls /usr/share/cloudstack-agent/lib/*.jar | tr '\n' ':' | sed s'/.$//'`
+PCP=`ls /usr/share/cloudstack-agent/plugins/*.jar 2>/dev/null | tr '\n' ':' | sed s'/.$//'`
+
+# We need to append the JSVC daemon JAR to the classpath
+# AgentShell implements the JSVC daemon methods
+export CLASSPATH="/usr/share/java/commons-daemon.jar:$ACP:$PCP:/etc/cloudstack/agent:/usr/share/cloudstack-common/scripts"
+
+start() {
+    echo -n $"Starting $PROGNAME: "
+    if hostname --fqdn >/dev/null 2>&1 ; then
+        $JSVC -Xms256m -Xmx2048m -cp "$CLASSPATH" -pidfile "$PIDFILE" \
+            -errfile $LOGDIR/cloudstack-agent.err -outfile $LOGDIR/cloudstack-agent.out $CLASS
+        RETVAL=$?
+        echo
+    else
+        failure
+        echo
+        echo The host name does not resolve properly to an IP address.  Cannot start "$PROGNAME". > /dev/stderr
+        RETVAL=9
+    fi
+    [ $RETVAL = 0 ] && touch ${LOCKFILE}
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping $PROGNAME: "
+    $JSVC -pidfile "$PIDFILE" -stop $CLASS
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && rm -f ${LOCKFILE} ${PIDFILE}
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status -p ${PIDFILE} $SHORTNAME
+        RETVAL=$?
+        ;;
+    restart)
+        stop
+        sleep 3
+        start
+        ;;
+    condrestart)
+        if status -p ${PIDFILE} $SHORTNAME >&/dev/null; then
+            stop
+            sleep 3
+            start
+        fi
+        ;;
+    *)
+    echo $"Usage: $SHORTNAME {start|stop|restart|condrestart|status|help}"
+    RETVAL=3
+esac
+
+exit $RETVAL

--- a/packaging/centos7/cloud-ipallocator.rc
+++ b/packaging/centos7/cloud-ipallocator.rc
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# chkconfig: 35 99 10
+# description: Cloud Agent
+
+# WARNING: if this script is changed, then all other initscripts MUST BE changed to match it as well
+
+. /etc/rc.d/init.d/functions
+
+# set environment variables
+
+SHORTNAME="$(basename $(readlink -f $0))"
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+LOGFILE=/var/log/cloudstack/ipallocator/ipallocator.log
+PROGNAME="External IPAllocator"
+
+unset OPTIONS
+[ -r /etc/sysconfig/"$SHORTNAME" ] && source /etc/sysconfig/"$SHORTNAME"
+DAEMONIZE=/usr/bin/cloud-daemonize
+PROG=/usr/bin/cloud-external-ipallocator.py
+OPTIONS=8083
+
+start() {
+        echo -n $"Starting $PROGNAME: "
+	if hostname --fqdn >/dev/null 2>&1 ; then
+		daemon --check=$SHORTNAME --pidfile=${PIDFILE} "$DAEMONIZE" \
+			-n "$SHORTNAME" -p "$PIDFILE" -l "$LOGFILE" "$PROG" $OPTIONS
+		RETVAL=$?
+		echo
+	else
+		failure
+		echo
+		echo The host name does not resolve properly to an IP address.  Cannot start "$PROGNAME". > /dev/stderr
+		RETVAL=9
+	fi
+	[ $RETVAL = 0 ] && touch ${LOCKFILE}
+	return $RETVAL
+}
+
+stop() {
+	echo -n $"Stopping $PROGNAME: "
+	killproc -p ${PIDFILE} $SHORTNAME # -d 10 $SHORTNAME
+	RETVAL=$?
+	echo
+	[ $RETVAL = 0 ] && rm -f ${LOCKFILE} ${PIDFILE}
+}
+
+
+# See how we were called.
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  status)
+        status -p ${PIDFILE} $SHORTNAME
+	RETVAL=$?
+	;;
+  restart)
+	stop
+	sleep 3
+	start
+	;;
+  condrestart)
+	if status -p ${PIDFILE} $SHORTNAME >&/dev/null; then
+		stop
+		sleep 3
+		start
+	fi
+	;;
+  *)
+	echo $"Usage: $SHORTNAME {start|stop|restart|condrestart|status|help}"
+	RETVAL=3
+esac
+
+exit $RETVAL
+

--- a/packaging/centos7/cloud-management.service
+++ b/packaging/centos7/cloud-management.service
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Systemd unit file for Cosmic Management server
+# 
+# clone tomcat service, see /usr/lib/systemd/system/tomcat.service
+
+[Unit]
+Description=Cosmic Management Server
+After=syslog.target network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/tomcat/tomcat.conf
+Environment="NAME=cloudstack-management"
+EnvironmentFile=-/etc/sysconfig/cloudstack-management
+ExecStart=/usr/libexec/tomcat/server start
+ExecStop=/usr/libexec/tomcat/server stop
+SuccessExitStatus=143
+User=cloud
+Group=cloud
+
+[Install]
+WantedBy=multi-user.target
+

--- a/packaging/centos7/cloud-management.sysconfig
+++ b/packaging/centos7/cloud-management.sysconfig
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Required for a tocmat cloned service
+SERVICE_NAME=cloudstack-management
+
+# Where your java installation lives
+#JAVA_HOME="/usr/lib/jvm/java"
+
+# Where your cloudstack-management installation lives
+CATALINA_BASE="/usr/share/cloudstack-management"
+CATALINA_HOME="/usr/share/cloudstack-management"
+JASPER_HOME="/usr/share/cloudstack-management"
+CATALINA_TMPDIR="/usr/share/cloudstack-management/temp"
+
+
+if [ -r "/etc/cloudstack/management/cloudmanagementserver.keystore" ] ; then
+  JAVA_OPTS="-Djava.awt.headless=true -Dcom.sun.management.jmxremote=false -Xmx2g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/cloudstack/management/ -XX:PermSize=512M -XX:MaxPermSize=800m -Djavax.net.ssl.trustStore=/etc/cloudstack/management/cloudmanagementserver.keystore -Djavax.net.ssl.trustStorePassword=vmops.com "
+else
+  JAVA_OPTS="-Djava.awt.headless=true -Dcom.sun.management.jmxremote=false -Xmx2g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/cloudstack/management/ -XX:PermSize=512M -XX:MaxPermSize=800m"
+fi
+
+TOMCAT_USER="cloud"
+
+SECURITY_MANAGER="false"
+
+SHUTDOWN_WAIT="30"
+
+SHUTDOWN_VERBOSE="false"
+
+# Set the TOMCAT_PID location
+CATALINA_PID="/var/run/cloudstack-management.pid"
+
+CLASSPATH=/etc/cloudstack/management:/usr/share/cloudstack-common:/usr/share/cloudstack-management/setup:/usr/share/java/mysql-connector-java.jar
+

--- a/packaging/centos7/cloud.limits
+++ b/packaging/centos7/cloud.limits
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cloud hard nofile 4096
+cloud soft nofile 4096

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -1,0 +1,550 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+%define __os_install_post %{nil}
+%global debug_package %{nil}
+
+# DISABLE the post-percentinstall java repacking and line number stripping
+# we need to find a way to just disable the java repacking and line number stripping, but not the autodeps
+
+Name:      cloudstack
+Summary:   Cosmic IaaS Platform
+#http://fedoraproject.org/wiki/PackageNamingGuidelines#Pre-Release_packages
+%if "%{?_prerelease}" != ""
+%define _maventag %{_ver}-SNAPSHOT
+Release:   %{_rel}%{dist}
+%else
+%define _maventag %{_ver}
+Release:   %{_rel}%{dist}
+%endif
+
+%{!?python_sitearch: %define python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
+
+Version:   %{_ver}
+License:   ASL 2.0
+Vendor:    Cosmic <int-cloud@schubergphilis.com>
+Packager:  Cosmic <int-cloud@schubergphilis.com>
+Group:     System Environment/Libraries
+# FIXME do groups for every single one of the subpackages
+Source0:   %{name}-%{_maventag}.tgz
+BuildRoot: %{_tmppath}/%{name}-%{_maventag}-%{release}-build
+
+BuildRequires: java-1.7.0-openjdk-devel
+BuildRequires: tomcat => 7.0
+BuildRequires: ws-commons-util
+BuildRequires: jpackage-utils
+BuildRequires: gcc
+BuildRequires: glibc-devel
+BuildRequires: /usr/bin/mkisofs
+BuildRequires: MySQL-python
+BuildRequires: maven => 3.0.0
+
+%description
+Cosmic is a highly-scalable elastic, open source,
+intelligent IaaS cloud implementation.
+
+%package management
+Summary:  Cosmic management server UI
+Requires: tomcat => 7.0
+Requires: java => 1.7.0
+Requires: python
+Requires: bash
+Requires: bzip2
+Requires: gzip
+Requires: unzip
+Requires: /sbin/mount.nfs
+Requires: openssh-clients
+Requires: nfs-utils
+Requires: wget
+Requires: mysql
+Requires: mysql-connector-java
+Requires: ws-commons-util
+Requires: jpackage-utils
+Requires: sudo
+Requires: /sbin/service
+Requires: /sbin/chkconfig
+Requires: /usr/bin/ssh-keygen
+Requires: mkisofs
+Requires: MySQL-python
+Requires: ipmitool
+Requires: %{name}-common = %{_ver}
+Requires: iptables-services
+Group:     System Environment/Libraries
+%description management
+The Cosmic management server is the central point of coordination,
+management, and intelligence in Cosmic.
+
+%package common
+Summary: Cosmic common files and scripts
+Requires: python
+Group:   System Environment/Libraries
+%description common
+The Cosmic files shared between agent and management server
+
+%package agent
+Summary: Cosmic Agent for KVM hypervisors
+Requires: openssh-clients
+Requires: java => 1.7.0
+Requires: %{name}-common = %{_ver}
+Requires: libvirt
+Requires: bridge-utils
+Requires: ebtables
+Requires: iptables
+Requires: ethtool
+Requires: iproute
+Requires: ipset
+Requires: perl
+Requires: libvirt-python
+Requires: qemu-img
+Requires: qemu-kvm
+Provides: cloud-agent
+Group: System Environment/Libraries
+%description agent
+The Cosmic agent for KVM hypervisors
+
+%package baremetal-agent
+Summary: Cosmic baremetal agent
+Requires: tftp-server
+Requires: xinetd
+Requires: syslinux
+Requires: chkconfig
+Requires: dhcp
+Requires: httpd
+Group:     System Environment/Libraries
+%description baremetal-agent
+The Cosmic baremetal agent
+
+%package usage
+Summary: Cosmic Usage calculation server
+Requires: java => 1.7.0
+Requires: mysql-connector-java
+Group: System Environment/Libraries
+%description usage
+The Cosmic usage calculation service
+
+%package cli
+Summary: Cosmic CLI
+Provides: python-cloudmonkey
+Provides: python-marvin
+Group: System Environment/Libraries
+%description cli
+Cosmic command line interface
+
+%if "%{_ossnoss}" == "noredist"
+%package mysql-ha
+Summary: Cosmic Balancing Strategy for MySQL
+Requires: mysql-connector-java
+Requires: tomcat => 7.0
+Group: System Environmnet/Libraries
+%description mysql-ha
+Cosmic Balancing Strategy for MySQL
+
+%endif
+
+%prep
+echo Doing Cosmic build
+
+%setup -q -n %{name}-%{_maventag}
+
+%build
+
+mkdir -p build
+cp packaging/centos7/replace.properties build/replace.properties
+echo VERSION=%{_maventag} >> build/replace.properties
+echo PACKAGE=%{name} >> build/replace.properties
+touch build/gitrev.txt
+echo $(git rev-parse HEAD) > build/gitrev.txt
+
+if [ "%{_ossnoss}" == "NOREDIST" -o "%{_ossnoss}" == "noredist" ] ; then
+   echo "Adding noredist flag to the maven build"
+   FLAGS="$FLAGS -Dnoredist"
+fi
+
+if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then
+   echo "Adding simulator flag to the maven build"
+   FLAGS="$FLAGS -Dsimulator"
+fi
+
+mvn -Psystemvm $FLAGS clean package
+
+%install
+[ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
+# Common directories
+mkdir -p ${RPM_BUILD_ROOT}%{_bindir}
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/ipallocator
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
+mkdir -p ${RPM_BUILD_ROOT}%{_initrddir}
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/sysconfig
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/profile.d
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d
+
+# Common
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms
+mkdir -p ${RPM_BUILD_ROOT}%{python_sitearch}/
+mkdir -p ${RPM_BUILD_ROOT}%/usr/bin
+cp -r cosmic-core/scripts/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+install -D cosmic-core/systemvm/dist/systemvm.iso ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms/systemvm.iso
+install -D cosmic-core/systemvm/dist/systemvm.zip ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms/systemvm.zip
+install cosmic-core/python/lib/cloud_utils.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloud_utils.py
+cp -r cosmic-core/python/lib/cloudutils ${RPM_BUILD_ROOT}%{python_sitearch}/
+python -m py_compile ${RPM_BUILD_ROOT}%{python_sitearch}/cloud_utils.py
+python -m compileall ${RPM_BUILD_ROOT}%{python_sitearch}/cloudutils
+cp build/gitrev.txt ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+cp packaging/centos7/cloudstack-sccs ${RPM_BUILD_ROOT}/usr/bin
+
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts/network/cisco
+cp -r cosmic-core/plugins/network-elements/cisco-vnmc/scripts/network/cisco/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts/network/cisco
+
+# Management
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/run
+
+# Specific for tomcat
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+ln -sf /usr/share/tomcat/bin ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/bin
+ln -sf /etc/%{name}/management ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/conf
+ln -sf /usr/share/tomcat/lib ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/lib
+ln -sf /var/log/%{name}/management ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/logs
+ln -sf /var/cache/%{name}/management/temp ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/temp
+ln -sf /var/cache/%{name}/management/work ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/work
+
+/bin/touch ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management/catalina.out
+
+install -D cosmic-core/client/target/utilities/bin/cloud-migrate-databases ${RPM_BUILD_ROOT}%{_bindir}/%{name}-migrate-databases
+install -D cosmic-core/client/target/utilities/bin/cloud-set-guest-password ${RPM_BUILD_ROOT}%{_bindir}/%{name}-set-guest-password
+install -D cosmic-core/client/target/utilities/bin/cloud-set-guest-sshkey ${RPM_BUILD_ROOT}%{_bindir}/%{name}-set-guest-sshkey
+install -D cosmic-core/client/target/utilities/bin/cloud-setup-databases ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-databases
+install -D cosmic-core/client/target/utilities/bin/cloud-setup-encryption ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-encryption
+install -D cosmic-core/client/target/utilities/bin/cloud-setup-management ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-management
+install -D cosmic-core/client/target/utilities/bin/cloud-setup-baremetal ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-baremetal
+install -D cosmic-core/client/target/utilities/bin/cloud-sysvmadm ${RPM_BUILD_ROOT}%{_bindir}/%{name}-sysvmadm
+install -D cosmic-core/client/target/utilities/bin/cloud-update-xenserver-licenses ${RPM_BUILD_ROOT}%{_bindir}/%{name}-update-xenserver-licenses
+
+cp -r cosmic-core/client/target/utilities/scripts/db/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup
+cp -r cosmic-core/client/target/cloud-client-ui-%{_maventag}/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client
+
+# Don't package the scripts in the management webapp
+rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/scripts
+rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/vms
+
+for name in db.properties log4j-cloud.xml server7-nonssl.xml server7-ssl.xml \
+            commons-logging.properties catalina.policy catalina.properties classpath.conf \
+            tomcat-users.xml web.xml environment.properties java.security.ciphers
+do
+  mv ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/$name \
+    ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/$name
+done
+
+ln -s %{_sysconfdir}/%{name}/management/log4j-cloud.xml \
+    ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/log4j-cloud.xml
+
+mv ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/context.xml \
+    ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+
+install cosmic-core/python/bindir/cloud-external-ipallocator.py ${RPM_BUILD_ROOT}%{_bindir}/%{name}-external-ipallocator.py
+install -D cosmic-core/client/target/pythonlibs/jasypt-1.9.2.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/lib/jasypt-1.9.2.jar
+
+install -D packaging/centos7/cloud-ipallocator.rc ${RPM_BUILD_ROOT}%{_initrddir}/%{name}-ipallocator
+install -D packaging/centos7/cloud-management.sysconfig ${RPM_BUILD_ROOT}%{_sysconfdir}/sysconfig/%{name}-management
+install -D cosmic-core/server/target/conf/cloudstack-sudoers ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
+install -D packaging/centos7/cloud-management.service ${RPM_BUILD_ROOT}%{_unitdir}/%{name}-management.service
+install -D packaging/centos7/cloud.limits ${RPM_BUILD_ROOT}%{_sysconfdir}/security/limits.d/cloud
+touch ${RPM_BUILD_ROOT}%{_localstatedir}/run/%{name}-management.pid
+
+chmod 440 ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+
+# KVM Agent
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/plugins
+install -D packaging/systemd/cloudstack-agent.service ${RPM_BUILD_ROOT}%{_unitdir}/%{name}-agent.service
+install -D cosmic-core/agent/target/transformed/agent.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/agent.properties
+install -D cosmic-core/agent/target/transformed/environment.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/environment.properties
+install -D cosmic-core/agent/target/transformed/log4j-cloud.xml ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/log4j-cloud.xml
+install -D cosmic-core/agent/target/transformed/cloud-setup-agent ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-agent
+install -D cosmic-core/agent/target/transformed/cloudstack-agent-upgrade ${RPM_BUILD_ROOT}%{_bindir}/%{name}-agent-upgrade
+install -D cosmic-core/agent/target/transformed/libvirtqemuhook ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib/libvirtqemuhook
+install -D cosmic-core/agent/target/transformed/cloud-ssh ${RPM_BUILD_ROOT}%{_bindir}/%{name}-ssh
+install -D cosmic-core/agent/target/transformed/cloudstack-agent-profile.sh ${RPM_BUILD_ROOT}%{_sysconfdir}/profile.d/%{name}-agent-profile.sh
+install -D cosmic-core/agent/target/transformed/cloudstack-agent.logrotate ${RPM_BUILD_ROOT}%{_sysconfdir}/logrotate.d/%{name}-agent
+install -D cosmic-plugin-hypervisor-kvm/target/cloud-plugin-hypervisor-kvm-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%name-agent/lib/cloud-plugin-hypervisor-kvm-%{_maventag}.jar
+cp cosmic-plugin-hypervisor-kvm/target/dependencies/*  ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib
+
+# Usage server
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib
+install -D cosmic-core/usage/target/cloud-usage-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/cloud-usage-%{_maventag}.jar
+install -D cosmic-core/usage/target/transformed/db.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage/db.properties
+install -D cosmic-core/usage/target/transformed/log4j-cloud_usage.xml ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage/log4j-cloud.xml
+cp cosmic-core/usage/target/dependencies/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib/
+install -D packaging/systemd/cloudstack-usage.service ${RPM_BUILD_ROOT}%{_unitdir}/%{name}-usage.service
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/usage/
+
+# CLI
+cp -r cosmic-core/cloud-cli/cloudtool ${RPM_BUILD_ROOT}%{python_sitearch}/
+install cosmic-core/cloud-cli/cloudapis/cloud.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloudapis.py
+
+# MYSQL HA
+if [ "x%{_ossnoss}" == "xnoredist" ] ; then
+  mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-mysql-ha/lib
+  cp -r plugins/database/mysql-ha/target/cloud-plugin-database-mysqlha-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-mysql-ha/lib
+fi
+
+#License files from whisker
+install -D cosmic-core/tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-management-%{version}/NOTICE
+install -D cosmic-core/tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-management-%{version}/LICENSE
+install -D cosmic-core/tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-common-%{version}/NOTICE
+install -D cosmic-core/tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-common-%{version}/LICENSE
+install -D cosmic-core/tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-agent-%{version}/NOTICE
+install -D cosmic-core/tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-agent-%{version}/LICENSE
+install -D cosmic-core/tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+install -D cosmic-core/tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
+install -D cosmic-core/tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-cli-%{version}/NOTICE
+install -D cosmic-core/tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-cli-%{version}/LICENSE
+if [ "x%{_ossnoss}" == "xnoredist" ] ; then
+  install -D cosmic-core/tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-mysql-ha-%{version}/LICENSE
+  install -D cosmic-core/tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-mysql-ha-%{version}/NOTICE
+fi
+
+%clean
+[ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
+
+%preun management
+/usr/bin/systemctl stop cloudstack-management || true
+/usr/bin/systemctl off cloudstack-management || true
+
+%pre management
+id cloud > /dev/null 2>&1 || /usr/sbin/useradd -M -c "Cosmic unprivileged user" \
+     -r -s /bin/sh -d %{_localstatedir}/cloudstack/management cloud|| true
+
+rm -rf %{_localstatedir}/cache/cloudstack
+
+%post management
+if [ "$1" == "1" ] ; then
+    /usr/bin/systemctl on cloudstack-management > /dev/null 2>&1 || true
+fi
+
+if [ ! -f %{_datadir}/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util ] ; then
+    echo Please download vhd-util from http://download.cloud.com.s3.amazonaws.com/tools/vhd-util and put it in
+    echo %{_datadir}/cloudstack-common/scripts/vm/hypervisor/xenserver/
+fi
+
+%preun agent
+/sbin/service cloudstack-agent stop || true
+if [ "$1" == "0" ] ; then
+    /sbin/chkconfig --del cloudstack-agent > /dev/null 2>&1 || true
+fi
+
+%pre agent
+
+# save old configs if they exist (for upgrade). Otherwise we may lose them
+# when the old packages are erased. There are a lot of properties files here.
+if [ -d "%{_sysconfdir}/cloud" ] ; then
+    mv %{_sysconfdir}/cloud %{_sysconfdir}/cloud.rpmsave
+fi
+
+%post agent
+if [ "$1" == "1" ] ; then
+    echo "Running %{_bindir}/%{name}-agent-upgrade to update bridge name for upgrade from Cosmic 4.0.x (and before) to Cosmic 4.1 (and later)"
+    %{_bindir}/%{name}-agent-upgrade
+    if [ ! -d %{_sysconfdir}/libvirt/hooks ] ; then
+        mkdir %{_sysconfdir}/libvirt/hooks
+    fi
+    cp -a ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib/libvirtqemuhook %{_sysconfdir}/libvirt/hooks/qemu
+    /sbin/service libvirtd restart
+    /sbin/systemctl enable cloudstack-agent > /dev/null 2>&1 || true
+fi
+
+# if saved configs from upgrade exist, copy them over
+if [ -f "%{_sysconfdir}/cloud.rpmsave/agent/agent.properties" ]; then
+    mv %{_sysconfdir}/%{name}/agent/agent.properties  %{_sysconfdir}/%{name}/agent/agent.properties.rpmnew
+    cp -p %{_sysconfdir}/cloud.rpmsave/agent/agent.properties %{_sysconfdir}/%{name}/agent
+    # make sure we only do this on the first install of this RPM, don't want to overwrite on a reinstall
+    mv %{_sysconfdir}/cloud.rpmsave/agent/agent.properties %{_sysconfdir}/cloud.rpmsave/agent/agent.properties.rpmsave
+fi
+
+%pre usage
+id cloud > /dev/null 2>&1 || /usr/sbin/useradd -M -c "Cosmic unprivileged user" \
+     -r -s /bin/sh -d %{_localstatedir}/cloudstack/management cloud|| true
+
+%preun usage
+/sbin/service cloudstack-usage stop || true
+if [ "$1" == "0" ] ; then
+    /sbin/chkconfig --del cloudstack-usage > /dev/null 2>&1 || true
+fi
+
+%post usage
+if [ -f "%{_sysconfdir}/%{name}/management/db.properties" ]; then
+    echo Replacing db.properties with management server db.properties
+    rm -f %{_sysconfdir}/%{name}/usage/db.properties
+    ln -s %{_sysconfdir}/%{name}/management/db.properties %{_sysconfdir}/%{name}/usage/db.properties
+    /usr/bin/systemctl enable cloudstack-usage > /dev/null 2>&1 || true
+fi
+
+if [ -f "%{_sysconfdir}/%{name}/management/key" ]; then
+    echo Replacing key with management server key
+    rm -f %{_sysconfdir}/%{name}/usage/key
+    ln -s %{_sysconfdir}/%{name}/management/key %{_sysconfdir}/%{name}/usage/key
+fi
+
+#No default permission as the permission setup is complex
+%files management
+%defattr(-,root,root,-)
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina/localhost
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina/localhost/client
+%dir %{_datadir}/%{name}-management
+%dir %attr(0770,root,cloud) %{_localstatedir}/%{name}/mnt
+%dir %attr(0770,cloud,cloud) %{_localstatedir}/%{name}/management
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/work
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/temp
+%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/management
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}-management
+%config(noreplace) %{_sysconfdir}/sudoers.d/%{name}-management
+%config(noreplace) %{_sysconfdir}/security/limits.d/cloud
+%config(noreplace) %attr(0640,root,cloud) %{_sysconfdir}/%{name}/management/db.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/log4j-cloud.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/Catalina/localhost/client/context.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/catalina.policy
+%config(noreplace) %{_sysconfdir}/%{name}/management/catalina.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/classpath.conf
+%config(noreplace) %{_sysconfdir}/%{name}/management/server7-nonssl.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/server7-ssl.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/tomcat-users.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/web.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/environment.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/java.security.ciphers
+%config(noreplace) %{_sysconfdir}/%{name}/management/commons-logging.properties
+%attr(0755,root,root) %{_unitdir}/%{name}-management.service
+%attr(0755,cloud,cloud) %{_localstatedir}/run/%{name}-management.pid
+
+%attr(0755,root,root) %{_bindir}/%{name}-setup-management
+%attr(0755,root,root) %{_bindir}/%{name}-update-xenserver-licenses
+%{_datadir}/%{name}-management/webapps
+%{_datadir}/%{name}-management/bin
+%{_datadir}/%{name}-management/conf
+%{_datadir}/%{name}-management/lib
+%{_datadir}/%{name}-management/logs
+%{_datadir}/%{name}-management/temp
+%{_datadir}/%{name}-management/work
+%attr(0755,root,root) %{_bindir}/%{name}-setup-databases
+%attr(0755,root,root) %{_bindir}/%{name}-migrate-databases
+%attr(0755,root,root) %{_bindir}/%{name}-set-guest-password
+%attr(0755,root,root) %{_bindir}/%{name}-set-guest-sshkey
+%attr(0755,root,root) %{_bindir}/%{name}-sysvmadm
+%attr(0755,root,root) %{_bindir}/%{name}-setup-encryption
+%{_datadir}/%{name}-management/setup/*.sql
+%{_datadir}/%{name}-management/setup/db/*.sql
+%{_datadir}/%{name}-management/setup/*.sh
+%{_datadir}/%{name}-management/setup/server-setup.xml
+%attr(0755,root,root) %{_bindir}/%{name}-external-ipallocator.py
+%attr(0755,root,root) %{_initrddir}/%{name}-ipallocator
+%dir %attr(0770,root,root) %{_localstatedir}/log/%{name}/ipallocator
+%{_defaultdocdir}/%{name}-management-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-management-%{version}/NOTICE
+%attr(0644,cloud,cloud) %{_localstatedir}/log/%{name}/management/catalina.out
+
+%files agent
+%attr(0755,root,root) %{_bindir}/%{name}-setup-agent
+%attr(0755,root,root) %{_bindir}/%{name}-agent-upgrade
+%attr(0755,root,root) %{_bindir}/%{name}-ssh
+%attr(0644,root,root) %{_unitdir}/%{name}-agent.service
+%attr(0644,root,root) %{_sysconfdir}/profile.d/%{name}-agent-profile.sh
+%attr(0644,root,root) %{_sysconfdir}/logrotate.d/%{name}-agent
+%attr(0755,root,root) %{_datadir}/%{name}-common/scripts/network/cisco
+%config(noreplace) %{_sysconfdir}/%{name}/agent
+%dir %{_localstatedir}/log/%{name}/agent
+%attr(0644,root,root) %{_datadir}/%{name}-agent/lib/*.jar
+%attr(0755,root,root) %{_datadir}/%{name}-agent/lib/libvirtqemuhook
+%dir %{_datadir}/%{name}-agent/plugins
+%{_defaultdocdir}/%{name}-agent-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-agent-%{version}/NOTICE
+
+%files common
+%dir %attr(0755,root,root) %{python_sitearch}/cloudutils
+%dir %attr(0755,root,root) %{_datadir}/%{name}-common/vms
+%attr(0755,root,root) %{_datadir}/%{name}-common/scripts
+%attr(0755,root,root) /usr/bin/cloudstack-sccs
+%attr(0644, root, root) %{_datadir}/%{name}-common/vms/systemvm.iso
+%attr(0644, root, root) %{_datadir}/%{name}-common/vms/systemvm.zip
+%attr(0644,root,root) %{python_sitearch}/cloud_utils.py
+%attr(0644,root,root) %{python_sitearch}/cloud_utils.pyc
+%attr(0644,root,root) %{python_sitearch}/cloudutils/*
+%attr(0644, root, root) %{_datadir}/%{name}-common/lib/jasypt-1.9.2.jar
+%{_defaultdocdir}/%{name}-common-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-common-%{version}/NOTICE
+
+%files usage
+%attr(0644,root,root) %{_unitdir}/%{name}-usage.service
+%attr(0644,root,root) %{_datadir}/%{name}-usage/*.jar
+%attr(0644,root,root) %{_datadir}/%{name}-usage/lib/*.jar
+%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/usage
+%attr(0644,root,root) %{_sysconfdir}/%{name}/usage/db.properties
+%attr(0644,root,root) %{_sysconfdir}/%{name}/usage/log4j-cloud.xml
+%{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+
+%files cli
+%attr(0644,root,root) %{python_sitearch}/cloudapis.py
+%attr(0644,root,root) %{python_sitearch}/cloudtool/__init__.py
+%attr(0644,root,root) %{python_sitearch}/cloudtool/utils.py
+%{_defaultdocdir}/%{name}-cli-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-cli-%{version}/NOTICE
+
+%if "%{_ossnoss}" == "noredist"
+%files mysql-ha
+%defattr(0644,cloud,cloud,0755)
+%attr(0644,root,root) %{_datadir}/%{name}-mysql-ha/lib/*
+%{_defaultdocdir}/%{name}-mysql-ha-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-mysql-ha-%{version}/NOTICE
+%endif
+
+%files baremetal-agent
+%attr(0755,root,root) %{_bindir}/cloudstack-setup-baremetal
+
+%changelog
+* Thu Apr 30 2015 Rohit Yadav <bhaisaab@apache.org> 4.6.0
+- Remove awsapi package
+
+* Wed Nov 19 2014 Hugo Trippaers <hugo@apache.org> 4.6.0
+- Create a specific spec for CentOS 7
+
+* Fri Jul 4 2014 Hugo Trippaers <hugo@apache.org> 4.5.0
+- Add a package for the mysql ha module
+
+* Fri Oct 5 2012 Hugo Trippaers <hugo@apache.org> 4.1.0
+- new style spec file

--- a/packaging/centos7/cloudstack-agent.te
+++ b/packaging/centos7/cloudstack-agent.te
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module cloudstack-agent 1.0;
+
+require {
+	type nfs_t;
+	type system_conf_t;
+	type mount_t;
+	type qemu_t;
+	class file unlink;
+	class filesystem getattr;
+}
+
+#============= mount_t ==============
+allow mount_t system_conf_t:file unlink;
+
+#============= qemu_t ==============
+allow qemu_t nfs_t:filesystem getattr;

--- a/packaging/centos7/cloudstack-sccs
+++ b/packaging/centos7/cloudstack-sccs
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cat /usr/share/cloudstack-common/scripts/gitrev.txt

--- a/packaging/centos7/replace.properties
+++ b/packaging/centos7/replace.properties
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DBUSER=cloud
+DBPW=cloud
+DBROOTPW=
+MSLOG=vmops.log
+APISERVERLOG=api.log
+DBHOST=localhost
+COMPONENTS-SPEC=components-premium.xml
+REMOTEHOST=localhost
+AGENTCLASSPATH=
+AGENTLOG=/var/log/cloudstack/agent/agent.log
+AGENTLOGDIR=/var/log/cloudstack/agent/
+AGENTSYSCONFDIR=/etc/cloudstack/agent
+APISERVERLOG=/var/log/cloudstack/management/apilog.log
+BINDIR=/usr/bin
+COMMONLIBDIR=/usr/share/cloudstack-common
+CONFIGUREVARS=
+DEPSCLASSPATH=
+DOCDIR=
+IPALOCATORLOG=/var/log/cloudstack/management/ipallocator.log
+JAVADIR=/usr/share/java
+LIBEXECDIR=/usr/libexec
+LOCKDIR=/var/lock
+MSCLASSPATH=
+MSCONF=/etc/cloudstack/management
+MSENVIRON=/usr/share/cloudstack-management
+MSLOG=/var/log/cloudstack/management/management-server.log
+MSLOGDIR=/var/log/cloudstack/management/
+MSMNTDIR=/var/cloudstack/mnt
+MSUSER=cloud
+PIDDIR=/var/run
+PLUGINJAVADIR=/usr/share/cloudstack-management/plugin
+PREMIUMJAVADIR=/usr/share/cloudstack-management/premium
+PYTHONDIR=/usr/lib/python2.7/site-packages/
+SERVERSYSCONFDIR=/etc/sysconfig
+SETUPDATADIR=/usr/share/cloudstack-management/setup
+SYSCONFDIR=/etc/sysconfig
+SYSTEMCLASSPATH=
+SYSTEMJARS=
+USAGECLASSPATH=
+USAGELOG=/var/log/cloudstack/usage/usage.log
+USAGESYSCONFDIR=/etc/sysconfig

--- a/packaging/centos7/tomcat7/catalina.properties
+++ b/packaging/centos7/tomcat7/catalina.properties
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageAccess unless the
+# corresponding RuntimePermission ("accessClassInPackage."+package) has
+# been granted.
+package.access=sun.,org.apache.catalina.,org.apache.coyote.,org.apache.tomcat.,org.apache.jasper.,sun.beans.
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageDefinition unless the
+# corresponding RuntimePermission ("defineClassInPackage."+package) has
+# been granted.
+#
+# by default, no packages are restricted for definition, and none of
+# the class loaders supplied with the JDK call checkPackageDefinition.
+#
+package.definition=sun.,java.,org.apache.catalina.,org.apache.coyote.,org.apache.tomcat.,org.apache.jasper.
+
+#
+#
+# List of comma-separated paths defining the contents of the "common" 
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank,the JVM system loader will be used as Catalina's "common" 
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class 
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+common.loader=${catalina.base}/lib,${catalina.base}/lib/*.jar,${catalina.home}/lib,${catalina.home}/lib/*.jar,/usr/share/java/mysql-connector-java.jar,/usr/share/cloudstack-mysql-ha/lib/*jar
+
+#
+# List of comma-separated paths defining the contents of the "server" 
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank, the "common" loader will be used as Catalina's "server" 
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class 
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+server.loader=
+
+#
+# List of comma-separated paths defining the contents of the "shared" 
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_BASE path or absolute. If left as blank,
+# the "common" loader will be used as Catalina's "shared" loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class 
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository 
+# Please note that for single jars, e.g. bar.jar, you need the URL form
+# starting with file:.
+shared.loader=
+
+#
+# String cache configuration.
+tomcat.util.buf.StringCache.byte.enabled=true
+#tomcat.util.buf.StringCache.char.enabled=true
+#tomcat.util.buf.StringCache.trainThreshold=500000
+#tomcat.util.buf.StringCache.cacheSize=5000

--- a/packaging/centos7/tomcat7/commons-logging.properties
+++ b/packaging/centos7/tomcat7/commons-logging.properties
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This is the logging properties that goes to the war, there are two logging conf kept at the 
+# svn, one for developement (one at src/test-resources) and other for producation
+ 
+# Uncomment the next line to disable all logging.
+#org.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+
+# Uncomment the next line to enable the simple log based logging
+#org.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog
+
+# Uncomment the next line to enable log4j based logging
+org.apache.commons.logging.Log=org.apache.commons.logging.impl.Log4JLogger

--- a/packaging/centos7/tomcat7/db.properties
+++ b/packaging/centos7/tomcat7/db.properties
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# management server clustering parameters, change cluster.node.IP to the machine IP address
+# in which the management server(Tomcat) is running
+cluster.node.IP=127.0.0.1
+cluster.servlet.port=9090
+region.id=1
+
+# Cosmic database settings
+db.cloud.username=cloud
+db.cloud.password=ENC(vlzQjmqOV4s5q7n+S1OMbA==)
+db.cloud.host=localhost
+db.cloud.port=3306
+db.cloud.name=cloud
+
+# Cosmic database tuning parameters
+db.cloud.maxActive=250
+db.cloud.maxIdle=30
+db.cloud.maxWait=10000
+db.cloud.validationQuery=SELECT 1
+db.cloud.testOnBorrow=true
+db.cloud.testWhileIdle=true
+db.cloud.timeBetweenEvictionRunsMillis=40000
+db.cloud.minEvictableIdleTimeMillis=240000
+db.cloud.poolPreparedStatements=false
+db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true
+
+# Cosmic database SSL settings
+db.cloud.useSSL=false
+db.cloud.keyStore=
+db.cloud.keyStorePassword=
+db.cloud.trustStore=
+db.cloud.trustStorePassword=
+db.cloud.keyStorePassphrase=vmops.com
+
+# Encryption Settings
+db.cloud.encryption.type=file
+db.cloud.encrypt.secret=ENC(zaGuSF5a4KyWayn2t0yyjDa0HjdToVtZ)
+
+# usage database settings
+db.usage.password=ENC(cQEcN5aVucSYK+WUkPjDcw==)
+db.usage.username=cloud
+db.usage.host=localhost
+db.usage.port=3306
+db.usage.name=cloud_usage
+
+# usage database tuning parameters
+db.usage.maxActive=100
+db.usage.maxIdle=30
+db.usage.maxWait=10000
+db.usage.url.params=
+
+# Simulator database settings
+db.simulator.username=cloud
+db.simulator.password=cloud
+db.simulator.host=localhost
+db.simulator.port=3306
+db.simulator.name=simulator
+db.simulator.maxActive=250
+db.simulator.maxIdle=30
+db.simulator.maxWait=10000
+db.simulator.autoReconnect=true
+
+
+# High Availability And Cluster Properties
+db.ha.enabled=false
+db.ha.loadBalanceStrategy=com.cloud.utils.db.StaticStrategy
+# cloud stack Database
+db.cloud.slaves=localhost,localhost
+db.cloud.autoReconnect=true
+db.cloud.failOverReadOnly=false
+db.cloud.reconnectAtTxEnd=true
+db.cloud.autoReconnectForPools=true
+db.cloud.secondsBeforeRetryMaster=3600
+db.cloud.queriesBeforeRetryMaster=5000
+db.cloud.initialTimeout=3600
+
+#usage Database
+db.usage.slaves=localhost,localhost
+db.usage.autoReconnect=true
+db.usage.failOverReadOnly=false
+db.usage.reconnectAtTxEnd=true
+db.usage.autoReconnectForPools=true
+db.usage.secondsBeforeRetryMaster=3600
+db.usage.queriesBeforeRetryMaster=5000
+db.usage.initialTimeout=3600

--- a/packaging/centos7/tomcat7/environment.properties
+++ b/packaging/centos7/tomcat7/environment.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# management server compile-time environment parameters
+
+paths.script=/usr/share/cloudstack-common
+mount.parent=/var/cloudstack/mnt
+cloud-stack-components-specification=components.xml

--- a/packaging/centos7/tomcat7/java.security.ciphers
+++ b/packaging/centos7/tomcat7/java.security.ciphers
@@ -1,0 +1,18 @@
+ # Licensed to the Apache Software Foundation (ASF) under one
+ # or more contributor license agreements.  See the NOTICE file
+ # distributed with this work for additional information
+ # regarding copyright ownership.  The ASF licenses this file
+ # to you under the Apache License, Version 2.0 (the
+ # "License"); you may not use this file except in compliance
+ # with the License.  You may obtain a copy of the License at
+ #
+ #   http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing,
+ # software distributed under the License is distributed on an
+ # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ # KIND, either express or implied.  See the License for the
+ # specific language governing permissions and limitations
+ # under the License.
+
+jdk.tls.disabledAlgorithms=DH keySize < 128, RSA keySize < 128, DES keySize < 128, SHA1 keySize < 128, MD5 keySize < 128, RC4

--- a/packaging/centos7/tomcat7/log4j-cloud.xml
+++ b/packaging/centos7/tomcat7/log4j-cloud.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+   <throwableRenderer class="com.cloud.utils.log.CglibThrowableRenderer"/>
+
+   <!-- ================================= -->
+   <!-- Preserve messages in a local file -->
+   <!-- ================================= -->
+
+   <!-- A regular appender FIXME implement code that will close/reopen logs on SIGHUP by logrotate FIXME make the paths configurable using the build system -->
+   <appender name="FILE" class="org.apache.log4j.rolling.RollingFileAppender">
+      <param name="Append" value="true"/>
+      <param name="Threshold" value="TRACE"/>
+      <rollingPolicy class="org.apache.log4j.rolling.TimeBasedRollingPolicy">
+        <param name="FileNamePattern" value="/var/log/cloudstack/management/management-server.log.%d{yyyy-MM-dd}.gz"/>
+        <param name="ActiveFileName" value="/var/log/cloudstack/management/management-server.log"/>
+      </rollingPolicy>
+      <layout class="org.apache.log4j.EnhancedPatternLayout">
+         <param name="ConversionPattern" value="%d{ISO8601} %-5p [%c{1.}] (%t:%x) %m%n"/>
+      </layout>
+   </appender>
+   
+   <appender name="APISERVER" class="org.apache.log4j.rolling.RollingFileAppender">
+      <param name="Append" value="true"/>
+      <param name="Threshold" value="DEBUG"/>
+      <rollingPolicy class="org.apache.log4j.rolling.TimeBasedRollingPolicy">
+        <param name="FileNamePattern" value="/var/log/cloudstack/management/apilog.log.%d{yyyy-MM-dd}.gz"/>
+        <param name="ActiveFileName" value="/var/log/cloudstack/management/apilog.log"/>
+      </rollingPolicy>
+      <layout class="org.apache.log4j.EnhancedPatternLayout">
+         <param name="ConversionPattern" value="%d{ISO8601} %-5p [%c{1.}] (%t:%x) %m%n"/>
+      </layout>
+   </appender>
+
+   <!-- ============================== -->
+   <!-- Append warnings+ to the syslog if it is listening on UDP port FIXME make sysloghost configurable! -->
+   <!-- ============================== -->
+
+   <appender name="SYSLOG" class="org.apache.log4j.net.SyslogAppender">
+      <param name="Threshold" value="WARN"/>
+      <param name="SyslogHost" value="localhost"/>
+      <param name="Facility" value="LOCAL6"/>
+      <layout class="org.apache.log4j.PatternLayout">
+         <param name="ConversionPattern" value="%-5p [%c{3}] (%t:%x) %m%n"/>
+      </layout>
+   </appender>
+
+   <!-- ============================== -->
+   <!-- Append alerts to the syslog if it is configured -->
+   <!-- ============================== -->
+
+   <appender name="ALERTSYSLOG" class="org.apache.cloudstack.syslog.AlertsSyslogAppender">
+      <param name="Threshold" value="WARN"/>
+      <param name="SyslogHosts" value=""/>
+      <param name="Facility" value="LOCAL6"/>
+      <layout class="org.apache.log4j.PatternLayout">
+         <param name="ConversionPattern" value="%-5p [%c{3}] (%t:%x) %m%n"/>
+      </layout>
+   </appender>
+
+   <!-- ============================== -->
+   <!-- send alert warnings+ as the SNMP trap if it is configured! -->
+   <!-- ============================== -->
+
+   <appender name="SNMP" class="org.apache.cloudstack.alert.snmp.SnmpTrapAppender">
+      <param name="Threshold" value="WARN"/>
+      <param name="SnmpManagerIpAddresses" value=""/>
+      <param name="SnmpManagerPorts" value=""/>
+      <param name="SnmpManagerCommunities" value=""/>
+      <layout class="org.apache.cloudstack.alert.snmp.SnmpEnhancedPatternLayout">
+         <param name="PairDelimiter" value="//"/>
+         <param name="KeyValueDelimiter" value="::"/>
+      </layout>
+   </appender>
+
+   <!-- ============================== -->
+   <!-- Append messages to the console -->
+   <!-- ============================== -->
+
+   <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+      <param name="Target" value="System.out"/>
+      <param name="Threshold" value="INFO"/>
+      <layout class="org.apache.log4j.EnhancedPatternLayout">
+         <param name="ConversionPattern" value="%-5p [%c{1.}] (%t:%x) %m%n"/>
+      </layout>
+   </appender>
+
+   <!-- ================ -->
+   <!-- Limit categories -->
+   <!-- ================ -->
+
+   <category name="com.cloud">
+     <priority value="DEBUG"/>
+   </category>
+   
+   <category name="org.apache.cloudstack">
+     <priority value="DEBUG"/>
+   </category>
+   
+   <category name="org.apache.cloudstack">
+      <priority value="DEBUG"/>
+   </category>
+
+   <category name="com.cloud.utils.nio">
+     <priority value="INFO"/>
+   </category>
+   
+   <!-- Limit the org.apache category to INFO as its DEBUG is verbose -->
+   <category name="org.apache">
+      <priority value="INFO"/>
+   </category>
+
+   <category name="org.apache.cloudstack">
+      <priority value="DEBUG"/>
+   </category>
+
+   <category name="org.apache.cloudstack.api.command">
+      <priority value="TRACE"/>
+   </category>
+   
+   <category name="org">
+      <priority value="INFO"/>
+   </category>
+   
+   <category name="org.springframework">
+      <priority value="WARN"/>
+   </category>
+   
+   <category name="org.apache.cloudstack.spring.module.context.ResourceApplicationContext">
+      <priority value="WARN"/>
+   </category>
+   
+   <category name="net">
+     <priority value="INFO"/>
+   </category>
+
+   <category name="apiserver.com.cloud">
+     <priority value="DEBUG"/>
+   </category>
+
+   <logger name="apiserver.com.cloud" additivity="false">
+      <level value="DEBUG"/>
+      <appender-ref ref="APISERVER"/>
+   </logger>
+
+   <!-- Limit the com.amazonaws category to INFO as its DEBUG is verbose -->
+   <category name="com.amazonaws">
+      <priority value="INFO"/>
+   </category>
+
+   <!-- Limit the httpclient.wire category to INFO as its DEBUG is verbose -->
+   <category name="httpclient.wire">
+      <priority value="INFO"/>
+   </category>
+
+   <!-- ============================== -->
+   <!-- Add or remove these logger for SNMP, this logger is for SNMP alerts plugin -->
+   <!-- ============================== -->
+
+   <logger name="org.apache.cloudstack.alerts" additivity="false">
+      <level value="WARN"/>
+      <appender-ref ref="SYSLOG"/>
+      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="FILE"/>
+      <appender-ref ref="SNMP"/>
+      <appender-ref ref="ALERTSYSLOG"/>
+   </logger>
+
+   <!-- ======================= -->
+   <!-- Setup the Root category -->
+   <!-- ======================= -->
+
+   <root>
+      <level value="INFO"/>
+      <appender-ref ref="SYSLOG"/>
+      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="FILE"/>
+   </root>
+
+</log4j:configuration>

--- a/packaging/centos7/tomcat7/server.xml
+++ b/packaging/centos7/tomcat7/server.xml
@@ -1,0 +1,80 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
+  <Listener className="org.apache.catalina.core.JasperListener" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <Service name="CloudStackManagement">
+
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="25"/>
+
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               acceptCount="150"
+               enableLookups="false"
+               maxThreads="150"
+               maxHttpHeaderSize="8192"
+               redirectPort="8443" />
+
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log." suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/packaging/centos7/tomcat7/tomcat-users.xml
+++ b/packaging/centos7/tomcat7/tomcat-users.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tomcat-users>
+<!--
+  <role rolename="tomcat"/>
+  <role rolename="role1"/>
+  <user username="tomcat" password="tomcat" roles="tomcat"/>
+  <user username="both" password="tomcat" roles="tomcat,role1"/>
+  <user username="role1" password="tomcat" roles="role1"/>
+-->
+
+<!-- The host manager webapp is restricted to users with role "admin" -->
+<!--<user name="tomcat" password="password" roles="admin" />-->
+<!-- The manager webapp is restricted to users with role "manager" -->
+<!--<user name="tomcat" password="password" roles="manager" />-->
+</tomcat-users>

--- a/packaging/centos7/tomcat7/web.xml
+++ b/packaging/centos7/tomcat7/web.xml
@@ -1,0 +1,1188 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    version="2.5">
+
+  <!-- ======================== Introduction ============================== -->
+  <!-- This document defines default values for *all* web applications      -->
+  <!-- loaded into this instance of Tomcat.  As each application is         -->
+  <!-- deployed, this file is processed, followed by the                    -->
+  <!-- "/WEB-INF/web.xml" deployment descriptor from your own               -->
+  <!-- applications.                                                        -->
+  <!--                                                                      -->
+  <!-- WARNING:  Do not configure application-specific resources here!      -->
+  <!-- They should go in the "/WEB-INF/web.xml" file in your application.   -->
+
+
+  <!-- ================== Built In Servlet Definitions ==================== -->
+
+
+  <!-- The default servlet for all web applications, that serves static     -->
+  <!-- resources.  It processes all requests that are not mapped to other   -->
+  <!-- servlets with servlet mappings (defined either here or in your own   -->
+  <!-- web.xml file.  This servlet supports the following initialization    -->
+  <!-- parameters (default values are in square brackets):                  -->
+  <!--                                                                      -->
+  <!--   debug               Debugging detail level for messages logged     -->
+  <!--                       by this servlet.  [0]                          -->
+  <!--                                                                      -->
+  <!--   fileEncoding        Encoding to be used to read static resources   -->
+  <!--                       [platform default]                             -->
+  <!--                                                                      -->
+  <!--   input               Input buffer size (in bytes) when reading      -->
+  <!--                       resources to be served.  [2048]                -->
+  <!--                                                                      -->
+  <!--   listings            Should directory listings be produced if there -->
+  <!--                       is no welcome file in this directory?  [false] -->
+  <!--                       WARNING: Listings for directories with many    -->
+  <!--                       entries can be slow and may consume            -->
+  <!--                       significant proportions of server resources.   -->
+  <!--                                                                      -->
+  <!--   output              Output buffer size (in bytes) when writing     -->
+  <!--                       resources to be served.  [2048]                -->
+  <!--                                                                      -->
+  <!--   readonly            Is this context "read only", so HTTP           -->
+  <!--                       commands like PUT and DELETE are               -->
+  <!--                       rejected?  [true]                              -->
+  <!--                                                                      -->
+  <!--   readmeFile          File name to display with the directory        -->
+  <!--                       contents. [null]                               -->
+  <!--                                                                      -->
+  <!--   sendfileSize        If the connector used supports sendfile, this  -->
+  <!--                       represents the minimal file size in KB for     -->
+  <!--                       which sendfile will be used. Use a negative    -->
+  <!--                       value to always disable sendfile.  [48]        -->
+  <!--                                                                      -->
+  <!--   useAcceptRanges     Should the Accept-Ranges header be included    -->
+  <!--                       in responses where appropriate? [true]         -->
+  <!--                                                                      -->
+  <!--  For directory listing customization. Checks localXsltFile, then     -->
+  <!--  globalXsltFile, then defaults to original behavior.                 -->
+  <!--                                                                      -->
+  <!--   localXsltFile       Make directory listings an XML doc and         -->
+  <!--                       pass the result to this style sheet residing   -->
+  <!--                       in that directory. This overrides              -->
+  <!--                        globalXsltFile[null]                          -->
+  <!--                                                                      -->
+  <!--   globalXsltFile      Site wide configuration version of             -->
+  <!--                       localXsltFile This argument is expected        -->
+  <!--                       to be a physical file. [null]                  -->
+  <!--                                                                      -->
+  <!--                                                                      -->
+
+    <servlet>
+        <servlet-name>default</servlet-name>
+        <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>
+        <init-param>
+            <param-name>debug</param-name>
+            <param-value>0</param-value>
+        </init-param>
+        <init-param>
+            <param-name>listings</param-name>
+            <param-value>false</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+
+  <!-- This servlet has been deprecated due to security concerns. Servlets  -->
+  <!-- should be explicitly mapped in web.xml                               -->
+  <!--                                                                      -->
+  <!-- The "invoker" servlet, which executes anonymous servlet classes      -->
+  <!-- that have not been defined in a web.xml file.  Traditionally, this   -->
+  <!-- servlet is mapped to the URL pattern "/servlet/*", but you can map   -->
+  <!-- it to other patterns as well.  The extra path info portion of such a -->
+  <!-- request must be the fully qualified class name of a Java class that  -->
+  <!-- implements Servlet (or extends HttpServlet), or the servlet name     -->
+  <!-- of an existing servlet definition.     This servlet supports the     -->
+  <!-- following initialization parameters (default values are in square    -->
+  <!-- brackets):                                                           -->
+  <!--                                                                      -->
+  <!--   debug               Debugging detail level for messages logged     -->
+  <!--                       by this servlet.  [0]                          -->
+
+<!--
+    <servlet>
+        <servlet-name>invoker</servlet-name>
+        <servlet-class>
+          org.apache.catalina.servlets.InvokerServlet
+        </servlet-class>
+        <init-param>
+            <param-name>debug</param-name>
+            <param-value>0</param-value>
+        </init-param>
+        <load-on-startup>2</load-on-startup>
+    </servlet>
+-->
+
+
+  <!-- The JSP page compiler and execution servlet, which is the mechanism  -->
+  <!-- used by Tomcat to support JSP pages.  Traditionally, this servlet    -->
+  <!-- is mapped to the URL pattern "*.jsp".  This servlet supports the     -->
+  <!-- following initialization parameters (default values are in square    -->
+  <!-- brackets):                                                           -->
+  <!--                                                                      -->
+  <!--   checkInterval       If development is false and checkInterval is   -->
+  <!--                       greater than zero, background compilations are -->
+  <!--                       enabled. checkInterval is the time in seconds  -->
+  <!--                       between checks to see if a JSP page (and its   -->
+  <!--                       dependent files) needs to  be recompiled. [0]  -->
+  <!--                                                                      -->
+  <!--   classdebuginfo      Should the class file be compiled with         -->
+  <!--                       debugging information?  [true]                 -->
+  <!--                                                                      -->
+  <!--   classpath           What class path should I use while compiling   -->
+  <!--                       generated servlets?  [Created dynamically      -->
+  <!--                       based on the current web application]          -->
+  <!--                                                                      -->
+  <!--   compiler            Which compiler Ant should use to compile JSP   -->
+  <!--                       pages.  See the jasper documentation for more  -->
+  <!--                       information.                                   -->
+  <!--                                                                      -->
+  <!--   compilerSourceVM    Compiler source VM. [1.5]                      -->
+  <!--                                                                      -->
+  <!--   compilerTargetVM    Compiler target VM. [1.5]                      -->  
+  <!--                                                                      -->
+  <!--   development         Is Jasper used in development mode? If true,   -->
+  <!--                       the frequency at which JSPs are checked for    -->
+  <!--                       modification may be specified via the          -->
+  <!--                       modificationTestInterval parameter. [true]     -->
+  <!--                                                                      -->
+  <!--   displaySourceFragment                                              -->
+  <!--                       Should a source fragment be included in        -->
+  <!--                       exception messages? [true]                     -->
+  <!--                                                                      -->
+  <!--   dumpSmap            Should the SMAP info for JSR45 debugging be    -->
+  <!--                       dumped to a file? [false]                      -->
+  <!--                       False if suppressSmap is true                  -->
+  <!--                                                                      -->
+  <!--   enablePooling       Determines whether tag handler pooling is      -->
+  <!--                       enabled. This is a compilation option. It will -->
+  <!--                       not alter the behaviour of JSPs that have      -->
+  <!--                       already been compiled. [true]                  -->
+  <!--                                                                      -->
+  <!--   engineOptionsClass  Allows specifying the Options class used to    -->
+  <!--                       configure Jasper. If not present, the default  -->
+  <!--                       EmbeddedServletOptions will be used.           -->
+  <!--                                                                      -->
+  <!--   errorOnUseBeanInvalidClassAttribute                                -->
+  <!--                       Should Jasper issue an error when the value of -->
+  <!--                       the class attribute in an useBean action is    -->
+  <!--                       not a valid bean class?  [true]                -->
+  <!--                                                                      -->
+  <!--   fork                Tell Ant to fork compiles of JSP pages so that -->
+  <!--                       a separate JVM is used for JSP page compiles   -->
+  <!--                       from the one Tomcat is running in. [true]      -->
+  <!--                                                                      -->
+  <!--   genStrAsCharArray   Should text strings be generated as char       -->
+  <!--                       arrays, to improve performance in some cases?  -->
+  <!--                       [false]                                        -->
+  <!--                                                                      -->
+  <!--   ieClassId           The class-id value to be sent to Internet      -->
+  <!--                       Explorer when using <jsp:plugin> tags.         -->
+  <!--                       [clsid:8AD9C840-044E-11D1-B3E9-00805F499D93]   -->
+  <!--                                                                      -->
+  <!--   javaEncoding        Java file encoding to use for generating java  -->
+  <!--                       source files. [UTF8]                           -->
+  <!--                                                                      -->
+  <!--   keepgenerated       Should we keep the generated Java source code  -->
+  <!--                       for each page instead of deleting it? [true]   -->
+  <!--                                                                      -->
+  <!--   mappedfile          Should we generate static content with one     -->
+  <!--                       print statement per input line, to ease        -->
+  <!--                       debugging?  [true]                             -->
+  <!--                                                                      -->
+  <!--   modificationTestInterval                                           -->
+  <!--                       Causes a JSP (and its dependent files) to not  -->
+  <!--                       be checked for modification during the         -->
+  <!--                       specified time interval (in seconds) from the  -->
+  <!--                       last time the JSP was checked for              -->
+  <!--                       modification. A value of 0 will cause the JSP  -->
+  <!--                       to be checked on every access.                 -->
+  <!--                       Used in development mode only. [4]             -->
+  <!--                                                                      -->
+  <!--   scratchdir          What scratch directory should we use when      -->
+  <!--                       compiling JSP pages?  [default work directory  -->
+  <!--                       for the current web application]               -->
+  <!--                                                                      -->
+  <!--   suppressSmap        Should the generation of SMAP info for JSR45   -->
+  <!--                       debugging be suppressed?  [false]              -->
+  <!--                                                                      -->
+  <!--   trimSpaces          Should white spaces in template text between   -->
+  <!--                       actions or directives be trimmed?  [false]     -->
+  <!--                                                                      -->
+  <!--   xpoweredBy          Determines whether X-Powered-By response       -->
+  <!--                       header is added by generated servlet  [false]  -->
+  <!--                                                                      -->
+  <!-- If you wish to use Jikes to compile JSP pages:                       -->
+  <!--   Please see the "Using Jikes" section of the Jasper-HowTo           -->
+  <!--   page in the Tomcat documentation.                                  -->
+
+    <servlet>
+        <servlet-name>jsp</servlet-name>
+        <servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class>
+        <init-param>
+            <param-name>fork</param-name>
+            <param-value>false</param-value>
+        </init-param>
+        <init-param>
+            <param-name>xpoweredBy</param-name>
+            <param-value>false</param-value>
+        </init-param>
+        <load-on-startup>3</load-on-startup>
+    </servlet>
+
+
+  <!-- NOTE: An SSI Filter is also available as an alternative SSI          -->
+  <!-- implementation. Use either the Servlet or the Filter but NOT both.   -->
+  <!--                                                                      -->
+  <!-- Server Side Includes processing servlet, which processes SSI         -->
+  <!-- directives in HTML pages consistent with similar support in web      -->
+  <!-- servers like Apache.  Traditionally, this servlet is mapped to the   -->
+  <!-- URL pattern "*.shtml".  This servlet supports the following          -->
+  <!-- initialization parameters (default values are in square brackets):   -->
+  <!--                                                                      -->
+  <!--   buffered            Should output from this servlet be buffered?   -->
+  <!--                       (0=false, 1=true)  [0]                         -->
+  <!--                                                                      -->
+  <!--   debug               Debugging detail level for messages logged     -->
+  <!--                       by this servlet.  [0]                          -->
+  <!--                                                                      -->
+  <!--   expires             The number of seconds before a page with SSI   -->
+  <!--                       directives will expire.  [No default]          -->
+  <!--                                                                      -->
+  <!--   isVirtualWebappRelative                                            -->
+  <!--                       Should "virtual" paths be interpreted as       -->
+  <!--                       relative to the context root, instead of       -->
+  <!--                       the server root?  (0=false, 1=true) [0]        -->
+  <!--                                                                      -->
+  <!--   inputEncoding       The encoding to assume for SSI resources if    -->
+  <!--                       one is not available from the resource.        -->
+  <!--                       [Platform default]                             -->
+  <!--                                                                      -->
+  <!--   outputEncoding      The encoding to use for the page that results  -->
+  <!--                       from the SSI processing. [UTF-8]               -->
+
+<!--
+    <servlet>
+        <servlet-name>ssi</servlet-name>
+        <servlet-class>
+          org.apache.catalina.ssi.SSIServlet
+        </servlet-class>
+        <init-param>
+          <param-name>buffered</param-name>
+          <param-value>1</param-value>
+        </init-param>
+        <init-param>
+          <param-name>debug</param-name>
+          <param-value>0</param-value>
+        </init-param>
+        <init-param>
+          <param-name>expires</param-name>
+          <param-value>666</param-value>
+        </init-param>
+        <init-param>
+          <param-name>isVirtualWebappRelative</param-name>
+          <param-value>0</param-value>
+        </init-param>
+        <load-on-startup>4</load-on-startup>
+    </servlet>
+-->
+
+
+  <!-- Common Gateway Includes (CGI) processing servlet, which supports     -->
+  <!-- execution of external applications that conform to the CGI spec      -->
+  <!-- requirements.  Typically, this servlet is mapped to the URL pattern  -->
+  <!-- "/cgi-bin/*", which means that any CGI applications that are         -->
+  <!-- executed must be present within the web application.  This servlet   -->
+  <!-- supports the following initialization parameters (default values     -->
+  <!-- are in square brackets):                                             -->
+  <!--                                                                      -->
+  <!--   cgiPathPrefix        The CGI search path will start at             -->
+  <!--                        webAppRootDir + File.separator + this prefix. -->
+  <!--                        [WEB-INF/cgi]                                 -->
+  <!--                                                                      -->
+  <!--   debug                Debugging detail level for messages logged    -->
+  <!--                        by this servlet.  [0]                         -->
+  <!--                                                                      -->
+  <!--   executable           Name of the executable used to run the        -->
+  <!--                        script. [perl]                                -->
+  <!--                                                                      -->
+  <!--   parameterEncoding    Name of parameter encoding to be used with    -->
+  <!--                        CGI servlet.                                  -->
+  <!--                        [System.getProperty("file.encoding","UTF-8")] -->
+  <!--                                                                      -->
+  <!--   passShellEnvironment Should the shell environment variables (if    -->
+  <!--                        any) be passed to the CGI script? [false]     -->
+  <!--                                                                      -->
+  <!--   stderrTimeout        The time (in milliseconds) to wait for the    -->
+  <!--                        reading of stderr to complete before          -->
+  <!--                        terminating the CGI process. [2000]           -->
+
+<!--
+    <servlet>
+        <servlet-name>cgi</servlet-name>
+        <servlet-class>org.apache.catalina.servlets.CGIServlet</servlet-class>
+        <init-param>
+          <param-name>debug</param-name>
+          <param-value>0</param-value>
+        </init-param>
+        <init-param>
+          <param-name>cgiPathPrefix</param-name>
+          <param-value>WEB-INF/cgi</param-value>
+        </init-param>
+         <load-on-startup>5</load-on-startup>
+    </servlet>
+-->
+
+
+  <!-- ================ Built In Servlet Mappings ========================= -->
+
+
+  <!-- The servlet mappings for the built in servlets defined above.  Note  -->
+  <!-- that, by default, the CGI and SSI servlets are *not* mapped.  You    -->
+  <!-- must uncomment these mappings (or add them to your application's own -->
+  <!-- web.xml deployment descriptor) to enable these services              -->
+
+    <!-- The mapping for the default servlet -->
+    <servlet-mapping>
+        <servlet-name>default</servlet-name>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+
+    <!-- The mapping for the deprecated invoker servlet -->
+<!--
+    <servlet-mapping>
+        <servlet-name>invoker</servlet-name>
+        <url-pattern>/servlet/*</url-pattern>
+    </servlet-mapping>
+-->
+
+    <!-- The mapping for the JSP servlet -->
+    <servlet-mapping>
+        <servlet-name>jsp</servlet-name>
+        <url-pattern>*.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>jsp</servlet-name>
+        <url-pattern>*.jspx</url-pattern>
+    </servlet-mapping>
+
+    <!-- The mapping for the SSI servlet -->
+<!--
+    <servlet-mapping>
+        <servlet-name>ssi</servlet-name>
+        <url-pattern>*.shtml</url-pattern>
+    </servlet-mapping>
+-->
+
+    <!-- The mapping for the CGI Gateway servlet -->
+
+<!--
+    <servlet-mapping>
+        <servlet-name>cgi</servlet-name>
+        <url-pattern>/cgi-bin/*</url-pattern>
+    </servlet-mapping>
+-->
+
+
+  <!-- ================== Built In Filter Definitions ===================== -->
+
+  <!-- NOTE: An SSI Servlet is also available as an alternative SSI         -->
+  <!-- implementation. Use either the Servlet or the Filter but NOT both.   -->
+  <!--                                                                      -->
+  <!-- Server Side Includes processing filter, which processes SSI          -->
+  <!-- directives in HTML pages consistent with similar support in web      -->
+  <!-- servers like Apache.  Traditionally, this filter is mapped to the    -->
+  <!-- URL pattern "*.shtml", though it can be mapped to "*" as it will     -->
+  <!-- selectively enable/disable SSI processing based on mime types. For   -->
+  <!-- this to work you will need to uncomment the .shtml mime type         -->
+  <!-- definition towards the bottom of this file.                          -->
+  <!-- The contentType init param allows you to apply SSI processing to JSP -->
+  <!-- pages, javascript, or any other content you wish.  This filter       -->
+  <!-- supports the following initialization parameters (default values are -->
+  <!-- in square brackets):                                                 -->
+  <!--                                                                      -->
+  <!--   contentType         A regex pattern that must be matched before    -->
+  <!--                       SSI processing is applied.                     -->
+  <!--                       [text/x-server-parsed-html(;.*)?]              -->
+  <!--                                                                      -->
+  <!--   debug               Debugging detail level for messages logged     -->
+  <!--                       by this servlet.  [0]                          -->
+  <!--                                                                      -->
+  <!--   expires             The number of seconds before a page with SSI   -->
+  <!--                       directives will expire.  [No default]          -->
+  <!--                                                                      -->
+  <!--   isVirtualWebappRelative                                            -->
+  <!--                       Should "virtual" paths be interpreted as       -->
+  <!--                       relative to the context root, instead of       -->
+  <!--                       the server root?  (0=false, 1=true) [0]        -->
+
+<!--
+    <filter>
+        <filter-name>ssi</filter-name>
+        <filter-class>
+          org.apache.catalina.ssi.SSIFilter
+        </filter-class>
+        <init-param>
+          <param-name>contentType</param-name>
+          <param-value>text/x-server-parsed-html(;.*)?</param-value>
+        </init-param>
+        <init-param>
+          <param-name>debug</param-name>
+          <param-value>0</param-value>
+        </init-param>
+        <init-param>
+          <param-name>expires</param-name>
+          <param-value>666</param-value>
+        </init-param>
+        <init-param>
+          <param-name>isVirtualWebappRelative</param-name>
+          <param-value>0</param-value>
+        </init-param>
+    </filter>
+-->
+
+
+  <!-- ==================== Built In Filter Mappings ====================== -->
+
+  <!-- The mapping for the SSI Filter -->
+<!--
+    <filter-mapping>
+        <filter-name>ssi</filter-name>
+        <url-pattern>*.shtml</url-pattern>
+    </filter-mapping>
+-->
+
+
+  <!-- ==================== Default Session Configuration ================= -->
+  <!-- You can set the default session timeout (in minutes) for all newly   -->
+  <!-- created sessions by modifying the value below.                       -->
+
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+
+
+  <!-- ===================== Default MIME Type Mappings =================== -->
+  <!-- When serving static resources, Tomcat will automatically generate    -->
+  <!-- a "Content-Type" header based on the resource's filename extension,  -->
+  <!-- based on these mappings.  Additional mappings can be added here (to  -->
+  <!-- apply to all web applications), or in your own application's web.xml -->
+  <!-- deployment descriptor.                                               -->
+
+    <mime-mapping>
+        <extension>abs</extension>
+        <mime-type>audio/x-mpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>ai</extension>
+        <mime-type>application/postscript</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>aif</extension>
+        <mime-type>audio/x-aiff</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>aifc</extension>
+        <mime-type>audio/x-aiff</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>aiff</extension>
+        <mime-type>audio/x-aiff</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>aim</extension>
+        <mime-type>application/x-aim</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>art</extension>
+        <mime-type>image/x-jg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>asf</extension>
+        <mime-type>video/x-ms-asf</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>asx</extension>
+        <mime-type>video/x-ms-asf</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>au</extension>
+        <mime-type>audio/basic</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>avi</extension>
+        <mime-type>video/x-msvideo</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>avx</extension>
+        <mime-type>video/x-rad-screenplay</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>bcpio</extension>
+        <mime-type>application/x-bcpio</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>bin</extension>
+        <mime-type>application/octet-stream</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>bmp</extension>
+        <mime-type>image/bmp</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>body</extension>
+        <mime-type>text/html</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>cdf</extension>
+        <mime-type>application/x-cdf</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>cer</extension>
+        <mime-type>application/x-x509-ca-cert</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>class</extension>
+        <mime-type>application/java</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>cpio</extension>
+        <mime-type>application/x-cpio</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>csh</extension>
+        <mime-type>application/x-csh</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>css</extension>
+        <mime-type>text/css</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>dib</extension>
+        <mime-type>image/bmp</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>doc</extension>
+        <mime-type>application/msword</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>dtd</extension>
+        <mime-type>application/xml-dtd</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>dv</extension>
+        <mime-type>video/x-dv</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>dvi</extension>
+        <mime-type>application/x-dvi</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>eps</extension>
+        <mime-type>application/postscript</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>etx</extension>
+        <mime-type>text/x-setext</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>exe</extension>
+        <mime-type>application/octet-stream</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>gif</extension>
+        <mime-type>image/gif</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>gtar</extension>
+        <mime-type>application/x-gtar</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>gz</extension>
+        <mime-type>application/x-gzip</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>hdf</extension>
+        <mime-type>application/x-hdf</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>hqx</extension>
+        <mime-type>application/mac-binhex40</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>htc</extension>
+        <mime-type>text/x-component</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>htm</extension>
+        <mime-type>text/html</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>html</extension>
+        <mime-type>text/html</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>hqx</extension>
+        <mime-type>application/mac-binhex40</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>ief</extension>
+        <mime-type>image/ief</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>jad</extension>
+        <mime-type>text/vnd.sun.j2me.app-descriptor</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>jar</extension>
+        <mime-type>application/java-archive</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>java</extension>
+        <mime-type>text/plain</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>jnlp</extension>
+        <mime-type>application/x-java-jnlp-file</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>jpe</extension>
+        <mime-type>image/jpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>jpeg</extension>
+        <mime-type>image/jpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>jpg</extension>
+        <mime-type>image/jpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>js</extension>
+        <mime-type>text/javascript</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>jsf</extension>
+        <mime-type>text/plain</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>jspf</extension>
+        <mime-type>text/plain</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>kar</extension>
+        <mime-type>audio/x-midi</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>latex</extension>
+        <mime-type>application/x-latex</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>m3u</extension>
+        <mime-type>audio/x-mpegurl</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mac</extension>
+        <mime-type>image/x-macpaint</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>man</extension>
+        <mime-type>application/x-troff-man</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mathml</extension>
+        <mime-type>application/mathml+xml</mime-type> 
+    </mime-mapping>
+    <mime-mapping>
+        <extension>me</extension>
+        <mime-type>application/x-troff-me</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mid</extension>
+        <mime-type>audio/x-midi</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>midi</extension>
+        <mime-type>audio/x-midi</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mif</extension>
+        <mime-type>application/x-mif</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mov</extension>
+        <mime-type>video/quicktime</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>movie</extension>
+        <mime-type>video/x-sgi-movie</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mp1</extension>
+        <mime-type>audio/x-mpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mp2</extension>
+        <mime-type>audio/x-mpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mp3</extension>
+        <mime-type>audio/x-mpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mp4</extension>
+        <mime-type>video/mp4</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mpa</extension>
+        <mime-type>audio/x-mpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mpe</extension>
+        <mime-type>video/mpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mpeg</extension>
+        <mime-type>video/mpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mpega</extension>
+        <mime-type>audio/x-mpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mpg</extension>
+        <mime-type>video/mpeg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>mpv2</extension>
+        <mime-type>video/mpeg2</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>ms</extension>
+        <mime-type>application/x-wais-source</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>nc</extension>
+        <mime-type>application/x-netcdf</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>oda</extension>
+        <mime-type>application/oda</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Database -->
+        <extension>odb</extension>
+        <mime-type>application/vnd.oasis.opendocument.database</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Chart -->
+        <extension>odc</extension>
+        <mime-type>application/vnd.oasis.opendocument.chart</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Formula -->
+        <extension>odf</extension>
+        <mime-type>application/vnd.oasis.opendocument.formula</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Drawing -->
+        <extension>odg</extension>
+        <mime-type>application/vnd.oasis.opendocument.graphics</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Image -->
+        <extension>odi</extension>
+        <mime-type>application/vnd.oasis.opendocument.image</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Master Document -->
+        <extension>odm</extension>
+        <mime-type>application/vnd.oasis.opendocument.text-master</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Presentation -->
+        <extension>odp</extension>
+        <mime-type>application/vnd.oasis.opendocument.presentation</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Spreadsheet -->
+        <extension>ods</extension>
+        <mime-type>application/vnd.oasis.opendocument.spreadsheet</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Text -->
+        <extension>odt</extension>
+        <mime-type>application/vnd.oasis.opendocument.text</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>ogg</extension>
+        <mime-type>application/ogg</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Drawing Template -->
+        <extension>otg </extension>
+        <mime-type>application/vnd.oasis.opendocument.graphics-template</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- HTML Document Template -->
+        <extension>oth</extension>
+        <mime-type>application/vnd.oasis.opendocument.text-web</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Presentation Template -->
+        <extension>otp</extension>
+        <mime-type>application/vnd.oasis.opendocument.presentation-template</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Spreadsheet Template -->
+        <extension>ots</extension>
+        <mime-type>application/vnd.oasis.opendocument.spreadsheet-template </mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- OpenDocument Text Template -->
+        <extension>ott</extension>
+        <mime-type>application/vnd.oasis.opendocument.text-template</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>pbm</extension>
+        <mime-type>image/x-portable-bitmap</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>pct</extension>
+        <mime-type>image/pict</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>pdf</extension>
+        <mime-type>application/pdf</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>pgm</extension>
+        <mime-type>image/x-portable-graymap</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>pic</extension>
+        <mime-type>image/pict</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>pict</extension>
+        <mime-type>image/pict</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>pls</extension>
+        <mime-type>audio/x-scpls</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>png</extension>
+        <mime-type>image/png</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>pnm</extension>
+        <mime-type>image/x-portable-anymap</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>pnt</extension>
+        <mime-type>image/x-macpaint</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>ppm</extension>
+        <mime-type>image/x-portable-pixmap</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>ppt</extension>
+        <mime-type>application/vnd.ms-powerpoint</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>pps</extension>
+        <mime-type>application/vnd.ms-powerpoint</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>ps</extension>
+        <mime-type>application/postscript</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>psd</extension>
+        <mime-type>image/x-photoshop</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>qt</extension>
+        <mime-type>video/quicktime</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>qti</extension>
+        <mime-type>image/x-quicktime</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>qtif</extension>
+        <mime-type>image/x-quicktime</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>ras</extension>
+        <mime-type>image/x-cmu-raster</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>rdf</extension>
+        <mime-type>application/rdf+xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>rgb</extension>
+        <mime-type>image/x-rgb</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>rm</extension>
+        <mime-type>application/vnd.rn-realmedia</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>roff</extension>
+        <mime-type>application/x-troff</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>rtf</extension>
+        <mime-type>application/rtf</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>rtx</extension>
+        <mime-type>text/richtext</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>sh</extension>
+        <mime-type>application/x-sh</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>shar</extension>
+        <mime-type>application/x-shar</mime-type>
+    </mime-mapping>
+<!--
+    <mime-mapping>
+        <extension>shtml</extension>
+        <mime-type>text/x-server-parsed-html</mime-type>
+    </mime-mapping>
+-->
+    <mime-mapping>
+        <extension>smf</extension>
+        <mime-type>audio/x-midi</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>sit</extension>
+        <mime-type>application/x-stuffit</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>snd</extension>
+        <mime-type>audio/basic</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>src</extension>
+        <mime-type>application/x-wais-source</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>sv4cpio</extension>
+        <mime-type>application/x-sv4cpio</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>sv4crc</extension>
+        <mime-type>application/x-sv4crc</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>svg</extension>
+        <mime-type>image/svg+xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>svgz</extension>
+        <mime-type>image/svg+xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>swf</extension>
+        <mime-type>application/x-shockwave-flash</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>t</extension>
+        <mime-type>application/x-troff</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>tar</extension>
+        <mime-type>application/x-tar</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>tcl</extension>
+        <mime-type>application/x-tcl</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>tex</extension>
+        <mime-type>application/x-tex</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>texi</extension>
+        <mime-type>application/x-texinfo</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>texinfo</extension>
+        <mime-type>application/x-texinfo</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>tif</extension>
+        <mime-type>image/tiff</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>tiff</extension>
+        <mime-type>image/tiff</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>tr</extension>
+        <mime-type>application/x-troff</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>tsv</extension>
+        <mime-type>text/tab-separated-values</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>txt</extension>
+        <mime-type>text/plain</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>ulw</extension>
+        <mime-type>audio/basic</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>ustar</extension>
+        <mime-type>application/x-ustar</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>vxml</extension>
+        <mime-type>application/voicexml+xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>xbm</extension>
+        <mime-type>image/x-xbitmap</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>xht</extension>
+        <mime-type>application/xhtml+xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>xhtml</extension>
+        <mime-type>application/xhtml+xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>xls</extension>
+        <mime-type>application/vnd.ms-excel</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>xml</extension>
+        <mime-type>application/xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>xpm</extension>
+        <mime-type>image/x-xpixmap</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>xsl</extension>
+        <mime-type>application/xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>xslt</extension>
+        <mime-type>application/xslt+xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>xul</extension>
+        <mime-type>application/vnd.mozilla.xul+xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>xwd</extension>
+        <mime-type>image/x-xwindowdump</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>vsd</extension>
+        <mime-type>application/x-visio</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>wav</extension>
+        <mime-type>audio/x-wav</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- Wireless Bitmap -->
+        <extension>wbmp</extension>
+        <mime-type>image/vnd.wap.wbmp</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- WML Source -->
+        <extension>wml</extension>
+        <mime-type>text/vnd.wap.wml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- Compiled WML -->
+        <extension>wmlc</extension>
+        <mime-type>application/vnd.wap.wmlc</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- WML Script Source -->
+        <extension>wmls</extension>
+        <mime-type>text/vnd.wap.wmlscript</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <!-- Compiled WML Script -->
+        <extension>wmlscriptc</extension>
+        <mime-type>application/vnd.wap.wmlscriptc</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>wmv</extension>
+        <mime-type>video/x-ms-wmv</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>wrl</extension>
+        <mime-type>x-world/x-vrml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>wspolicy</extension>
+        <mime-type>application/wspolicy+xml</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>Z</extension>
+        <mime-type>application/x-compress</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>z</extension>
+        <mime-type>application/x-compress</mime-type>
+    </mime-mapping>
+    <mime-mapping>
+        <extension>zip</extension>
+        <mime-type>application/zip</mime-type>
+    </mime-mapping>
+
+  <!-- ==================== Default Welcome File List ===================== -->
+  <!-- When a request URI refers to a directory, the default servlet looks  -->
+  <!-- for a "welcome file" within that directory and, if present,          -->
+  <!-- to the corresponding resource URI for display.  If no welcome file   -->
+  <!-- is present, the default servlet either serves a directory listing,   -->
+  <!-- or returns a 404 status, depending on how it is configured.          -->
+  <!--                                                                      -->
+  <!-- If you define welcome files in your own application's web.xml        -->
+  <!-- deployment descriptor, that list *replaces* the list configured      -->
+  <!-- here, so be sure that you include any of the default values that     -->
+  <!-- you wish to include.                                                 -->
+
+    <welcome-file-list>
+        <welcome-file>index.html</welcome-file>
+        <welcome-file>index.htm</welcome-file>
+        <welcome-file>index.jsp</welcome-file>
+    </welcome-file-list>
+
+</web-app>

--- a/packaging/debian/init/cloud-agent
+++ b/packaging/debian/init/cloud-agent
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+### BEGIN INIT INFO
+# Provides:          cloudstack-agent
+# Required-Start:    $network $local_fs
+# Required-Stop:     $network $local_fs
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Start/stop Apache CloudStack Agent
+# Description: This scripts Starts/Stops the Apache CloudStack agent
+##  The CloudStack Agent is a part of the Apache CloudStack project and is used
+##  for managing KVM-based Hypervisors and performing secondary storage tasks inside
+##  the Secondary Storage System Virtual Machine.
+## JSVC (Java daemonizing) is used for starting and stopping the agent
+### END INIT INFO
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+. /lib/lsb/init-functions
+
+SHORTNAME="cloudstack-agent"
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+PROGNAME="CloudStack Agent"
+CLASS="com.cloud.agent.AgentShell"
+PROG="jsvc"
+DAEMON="/usr/bin/jsvc"
+SHUTDOWN_WAIT="30"
+
+unset OPTIONS
+[ -r /etc/default/"$SHORTNAME" ] && source /etc/default/"$SHORTNAME"
+
+# The first existing directory is used for JAVA_HOME (if JAVA_HOME is not defined in $DEFAULT)
+JDK_DIRS="/usr/lib/jvm/java-7-openjdk-amd64 /usr/lib/jvm/java-7-openjdk-i386 /usr/lib/jvm/java-7-oracle /usr/lib/jvm/java-6-openjdk /usr/lib/jvm/java-6-openjdk-i386 /usr/lib/jvm/java-6-openjdk-amd64 /usr/lib/jvm/java-6-sun"
+
+for jdir in $JDK_DIRS; do
+    if [ -r "$jdir/bin/java" -a -z "${JAVA_HOME}" ]; then
+        JAVA_HOME="$jdir"
+    fi
+done
+export JAVA_HOME
+
+ACP=`ls /usr/share/cloudstack-agent/lib/*.jar | tr '\n' ':' | sed s'/.$//'`
+PCP=`ls /usr/share/cloudstack-agent/plugins/*.jar 2>/dev/null | tr '\n' ':' | sed s'/.$//'`
+
+# We need to append the JSVC daemon JAR to the classpath
+# AgentShell implements the JSVC daemon methods
+export CLASSPATH="/usr/share/java/commons-daemon.jar:$ACP:$PCP:/etc/cloudstack/agent"
+
+wait_for_network() {
+    i=1
+    while [ $i -lt 10 ]
+    do
+        # Under Ubuntu and Debian libvirt by default creates a bridge called virbr0.
+        # That's why we want more then 3 lines back from brctl, so that there is a manually created bridge
+        if [ "$(brctl show|wc -l)" -gt 2 ]; then
+            break
+        else
+            sleep 1
+            let i=$i+1
+            continue
+        fi
+    done
+}
+
+start() {
+    if [ -s "$PIDFILE" ] && kill -0 $(cat "$PIDFILE") >/dev/null 2>&1; then
+        log_daemon_msg "$PROGNAME apparently already running"
+        log_end_msg 0
+        exit 0
+    fi
+
+    log_daemon_msg "Starting $PROGNAME" "$SHORTNAME"
+    if hostname --fqdn >/dev/null 2>&1 ; then
+        true
+    else
+        log_failure_msg "The host name does not resolve properly to an IP address. Cannot start $PROGNAME"
+        log_end_msg 1
+        exit 1
+    fi
+
+    wait_for_network
+
+    if start_daemon -p $PIDFILE $DAEMON -Xms256m -Xmx2048m -cp "$CLASSPATH" -Djna.nosys=true -pidfile "$PIDFILE" -errfile SYSLOG $CLASS
+        RETVAL=$?
+    then
+        rc=0
+        sleep 1
+        if ! kill -0 $(cat "$PIDFILE") >/dev/null 2>&1; then
+            log_failure_msg "$PROG failed to start"
+            rc=1
+        fi
+    else
+        rc=1
+    fi
+
+    if [ $rc -eq 0 ]; then
+        log_end_msg 0
+    else
+        log_end_msg 1
+        rm -f "$PIDFILE"
+    fi
+}
+
+stop() {
+    count="0"
+
+    log_daemon_msg "Stopping $PROGNAME" "$SHORTNAME"
+    killproc -p $PIDFILE $DAEMON
+
+    until [ "$count" -gt "$SHUTDOWN_WAIT" ]
+    do
+        agentPid=$(ps aux|grep [j]svc|grep $SHORTNAME)
+        if [ "$?" -gt "0" ];then
+            break
+        fi
+        sleep 1
+        let count="${count}+1"
+    done
+
+    agentPid=$(ps aux|grep [j]svc|grep $SHORTNAME)
+    if [ "$?" -eq "0" ]; then
+        agentPid=$(ps aux|grep [j]svc|awk '{print $2}')
+        if [ "$agentPid" != "" ]; then
+            log_warning_msg "$PROG still running, forcing kill"
+            kill -9 $agentPid
+        fi
+    fi
+
+    log_end_msg $?
+    rm -f "$PIDFILE"
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status_of_proc -p "$PIDFILE" "$PROG" "$SHORTNAME"
+        RETVAL=$?
+        ;;
+    restart | force-reload)
+        stop
+        sleep 3
+        start
+        ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|force-reload|status}"
+    RETVAL=3
+esac
+
+exit $RETVAL

--- a/packaging/debian/init/cloud-management
+++ b/packaging/debian/init/cloud-management
@@ -1,0 +1,243 @@
+#!/bin/sh
+#
+# /etc/init.d/tomcat6 -- startup script for the Tomcat 6 servlet engine
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+### BEGIN INIT INFO
+# Provides:          cloudstack-management
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs $remote_fs $network
+# Should-Start:      $named
+# Should-Stop:       $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start Tomcat (CloudStack).
+# Description:       Start the Tomcat servlet engine that runs the CloudStack Management Server.
+### END INIT INFO
+
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+NAME=cloudstack-management
+DESC="CloudStack-specific Tomcat servlet engine"
+DAEMON=/usr/bin/jsvc
+CATALINA_HOME=/usr/share/cloudstack-management
+DEFAULT=/etc/cloudstack/management/tomcat6.conf
+JVM_TMP=/tmp/$NAME-temp
+
+# We have to explicitly set the HOME variable to the homedir from the user "cloud"
+# This is because various scripts run by the management server read the HOME variable
+# and fail when this init script is run manually.
+HOME=$(echo ~cloud)
+
+if [ `id -u` -ne 0 ]; then
+	echo "You need root privileges to run this script"
+	exit 1
+fi
+ 
+# Make sure tomcat is started with system locale
+if [ -r /etc/default/locale ]; then
+	. /etc/default/locale
+	export LANG
+fi
+
+. /lib/lsb/init-functions
+. /etc/default/rcS
+
+
+# The following variables can be overwritten in $DEFAULT
+
+# Run Tomcat 6 as this user ID
+TOMCAT6_USER=tomcat6
+
+# The first existing directory is used for JAVA_HOME (if JAVA_HOME is not
+# defined in $DEFAULT)
+JDK_DIRS="/usr/lib/jvm/java-7-openjdk-amd64 /usr/lib/jvm/java-7-openjdk-i386 /usr/lib/jvm/java-7-oracle /usr/lib/jvm/java-7-openjdk /usr/lib/jvm/java-7-sun"
+
+# Look for the right JVM to use
+for jdir in $JDK_DIRS; do
+    if [ -r "$jdir/bin/java" -a -z "${JAVA_HOME}" ]; then
+	JAVA_HOME="$jdir"
+    fi
+done
+export JAVA_HOME
+
+# Directory for per-instance configuration files and webapps
+CATALINA_BASE=/usr/share/cloudstack-management
+
+# Use the Java security manager? (yes/no)
+TOMCAT6_SECURITY=no
+
+# Default Java options
+# Set java.awt.headless=true if JAVA_OPTS is not set so the
+# Xalan XSL transformer can work without X11 display on JDK 1.4+
+# It also looks like the default heap size of 64M is not enough for most cases
+# so the maximum heap size is set to 128M
+if [ -z "$JAVA_OPTS" ]; then
+	JAVA_OPTS="-Djava.awt.headless=true -Xmx128M"
+fi
+
+# End of variables that can be overwritten in $DEFAULT
+
+# overwrite settings from default file
+if [ -f "$DEFAULT" ]; then
+	. "$DEFAULT"
+fi
+
+if [ ! -f "$CATALINA_HOME/bin/bootstrap.jar" ]; then
+	log_failure_msg "$NAME is not installed"
+	exit 1
+fi
+
+[ -f "$DAEMON" ] || exit 0
+
+POLICY_CACHE="$CATALINA_BASE/work/catalina.policy"
+
+JAVA_OPTS="$JAVA_OPTS -Djava.endorsed.dirs=$CATALINA_HOME/endorsed -Dcatalina.base=$CATALINA_BASE -Dcatalina.home=$CATALINA_HOME -Djava.io.tmpdir=$JVM_TMP"
+
+# Set the JSP compiler if set in the tomcat6.default file
+if [ -n "$JSP_COMPILER" ]; then
+	JAVA_OPTS="$JAVA_OPTS -Dbuild.compiler=$JSP_COMPILER"
+fi
+
+if [ "$TOMCAT6_SECURITY" = "yes" ]; then
+	JAVA_OPTS="$JAVA_OPTS -Djava.security.manager -Djava.security.policy=$POLICY_CACHE"
+fi
+
+# Set juli LogManager if logging.properties is provided
+if [ -r "$CATALINA_BASE"/conf/logging.properties ]; then
+  JAVA_OPTS="$JAVA_OPTS "-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager" "-Djava.util.logging.config.file="$CATALINA_BASE/conf/logging.properties"
+fi
+
+# Define other required variables
+CATALINA_PID="/var/run/$NAME.pid"
+BOOTSTRAP_CLASS=org.apache.catalina.startup.Bootstrap
+JSVC_CLASSPATH="/usr/share/java/commons-daemon.jar:$CATALINA_HOME/bin/bootstrap.jar:/etc/cloudstack/management:/usr/share/cloudstack-management/setup"
+
+# Look for Java Secure Sockets Extension (JSSE) JARs
+if [ -z "${JSSE_HOME}" -a -r "${JAVA_HOME}/jre/lib/jsse.jar" ]; then
+    JSSE_HOME="${JAVA_HOME}/jre/"
+fi
+export JSSE_HOME
+
+case "$1" in
+  start)
+	if [ -z "$JAVA_HOME" ]; then
+		log_failure_msg "no JDK found - please set JAVA_HOME"
+		exit 1
+	fi
+
+	if [ ! -d "$CATALINA_BASE/conf" ]; then
+		log_failure_msg "invalid CATALINA_BASE: $CATALINA_BASE"
+		exit 1
+	fi
+
+	log_daemon_msg "Starting $DESC" "$NAME"
+	if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
+		--user $TOMCAT6_USER --startas "$JAVA_HOME/bin/java" \
+		>/dev/null; then
+
+		# Regenerate POLICY_CACHE file
+		umask 022
+		echo "// AUTO-GENERATED FILE from /etc/tomcat6/policy.d/" \
+			> "$POLICY_CACHE"
+		echo ""  >> "$POLICY_CACHE"
+		if ls $CATALINA_BASE/conf/policy.d/*.policy > /dev/null 2>&1 ; then
+		cat $CATALINA_BASE/conf/policy.d/*.policy \
+			>> "$POLICY_CACHE"
+		fi
+
+		# Remove / recreate JVM_TMP directory
+		rm -rf "$JVM_TMP"
+		mkdir "$JVM_TMP" || {
+			log_failure_msg "could not create JVM temporary directory"
+			exit 1
+		}
+		chown $TOMCAT6_USER "$JVM_TMP"
+		cd "$JVM_TMP"
+
+
+		# fix storage issues on nfs mounts
+		umask 000
+		$DAEMON -user "$TOMCAT6_USER" -cp "$JSVC_CLASSPATH" \
+		    -outfile SYSLOG -errfile SYSLOG \
+		    -pidfile "$CATALINA_PID" $JAVA_OPTS "$BOOTSTRAP_CLASS"
+
+		sleep 5
+        	if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
+			--user $TOMCAT6_USER --startas "$JAVA_HOME/bin/java" \
+			>/dev/null; then
+			log_end_msg 1
+		else
+			log_end_msg 0
+		fi
+	else
+	        log_progress_msg "(already running)"
+		log_end_msg 0
+	fi
+	;;
+  stop)
+	log_daemon_msg "Stopping $DESC" "$NAME"
+        if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
+		--user "$TOMCAT6_USER" --startas "$JAVA_HOME/bin/java" \
+		>/dev/null; then
+		log_progress_msg "(not running)"
+	else
+		$DAEMON -cp "$JSVC_CLASSPATH" -pidfile "$CATALINA_PID" \
+		     -stop "$BOOTSTRAP_CLASS"
+	fi
+	rm -rf "$JVM_TMP"
+	log_end_msg 0
+	;;
+   status)
+        if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
+		--user $TOMCAT6_USER --startas "$JAVA_HOME/bin/java" \
+		>/dev/null; then
+
+		if [ -f "$CATALINA_PID" ]; then
+		    log_success_msg "$DESC is not running, but pid file exists."
+			exit 1
+		else
+		    log_success_msg "$DESC is not running."
+			exit 3
+		fi
+	else
+		log_success_msg "$DESC is running with pid `cat $CATALINA_PID`"
+	fi
+        ;;
+  restart|force-reload)
+        if start-stop-daemon --test --stop --pidfile "$CATALINA_PID" \
+		--user $TOMCAT6_USER --startas "$JAVA_HOME/bin/java" \
+		>/dev/null; then
+		$0 stop
+		sleep 1
+	fi
+	$0 start
+	;;
+  try-restart)
+        if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
+		--user $TOMCAT6_USER --startas "$JAVA_HOME/bin/java" \
+		>/dev/null; then
+		$0 start
+	fi
+        ;;
+  *)
+	log_success_msg "Usage: $0 {start|stop|restart|try-restart|force-reload|status}"
+	exit 1
+	;;
+esac
+
+exit 0

--- a/packaging/debian/init/cloud-usage
+++ b/packaging/debian/init/cloud-usage
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+### BEGIN INIT INFO
+# Provides:          cloudstack-usage
+# Required-Start:    $network $local_fs
+# Required-Stop:     $network $local_fs
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Start/stop Apache CloudStack Usage Monitor
+# Description: This scripts Starts/Stops the Apache CloudStack Usage Monitor
+##  The CloudStack Usage Monitor is a part of the Apache CloudStack project and is used
+##  for storing usage statistics from instances.
+## JSVC (Java daemonizing) is used for starting and stopping the usage monitor.
+### END INIT INFO
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+. /lib/lsb/init-functions
+
+SHORTNAME="cloudstack-usage"
+PIDFILE=/var/run/"$SHORTNAME".pid
+PROGNAME="CloudStack Usage Monitor"
+CLASS="com.cloud.usage.UsageServer"
+PROG="jsvc"
+DAEMON="/usr/bin/jsvc"
+
+unset OPTIONS
+[ -r /etc/default/"$SHORTNAME" ] && source /etc/default/"$SHORTNAME"
+
+setJavaHome() {
+  # use $JAVA_HOME if defined
+  if [ -n "$JAVA_HOME" ] ; then
+    return
+  fi
+
+  # try java first
+  java=$(which java 2>/dev/null || :)
+
+  # try javac if java is not found
+  if [ -z "$java" ] ; then
+    java=$(which javac 2>/dev/null || :)
+  fi
+
+  if [ -n "$java" ] ; then
+    JAVA_HOME=$(dirname $(dirname $(readlink -e $java)))
+    export JAVA_HOME
+    return
+  fi
+
+  # If everything has failed, try hardcoded paths
+  # The first existing directory is used for JAVA_HOME (if JAVA_HOME is not defined in $DEFAULT)
+  JDK_DIRS="/usr/lib/jvm/java-7-openjdk-amd64 /usr/lib/jvm/java-7-openjdk-i386 /usr/lib/jvm/java-7-oracle /usr/lib/jvm/java-7-openjdk /usr/lib/jvm/java-7-sun"
+  for jdir in $JDK_DIRS; do
+    if [ -r "$jdir/bin/java" -a -z "${JAVA_HOME}" ]; then
+      JAVA_HOME="$jdir"
+      export JAVA_HOME
+      return
+    fi
+  done
+
+  # didnt find java home. exiting with error
+  exit 1
+}
+
+setJavaHome
+
+UCP=`ls /usr/share/cloudstack-usage/lib/*.jar | tr '\n' ':' | sed s'/.$//'`
+PCP=`ls /usr/share/cloudstack-usage/plugins/*.jar 2>/dev/null | tr '\n' ':' | sed s'/.$//'`
+
+# We need to append the JSVC daemon JAR to the classpath
+# AgentShell implements the JSVC daemon methods
+export CLASSPATH="/usr/share/java/commons-daemon.jar:/usr/share/java/mysql-connector-java.jar:$UCP:$PCP:/etc/cloudstack/usage"
+
+start() {
+    if [ -s "$PIDFILE" ] && kill -0 $(cat "$PIDFILE") >/dev/null 2>&1; then
+        log_daemon_msg "$PROGNAME apparently already running"
+        log_end_msg 0
+        exit 0
+    fi
+
+    log_daemon_msg "Starting $PROGNAME" "$SHORTNAME"
+    if hostname --fqdn >/dev/null 2>&1 ; then
+        true
+    else
+        log_failure_msg "The host name does not resolve properly to an IP address. Cannot start $PROGNAME"
+        log_end_msg 1
+        exit 1
+    fi
+
+    if start_daemon -p $PIDFILE $DAEMON -home "$JAVA_HOME" -cp "$CLASSPATH" -pidfile "$PIDFILE" -outfile SYSLOG -errfile SYSLOG -Dpid=$$ $CLASS
+        RETVAL=$?
+    then
+        rc=0
+        sleep 1
+        if ! kill -0 $(cat "$PIDFILE") >/dev/null 2>&1; then
+            log_failure_msg "$PROG failed to start"
+            rc=1
+        fi
+    else
+        rc=1
+    fi
+
+    if [ $rc -eq 0 ]; then
+        log_end_msg 0
+    else
+        log_end_msg 1
+        rm -f "$PIDFILE"
+    fi
+}
+
+stop() {
+    log_daemon_msg "Stopping $PROGNAME" "$SHORTNAME"
+    killproc -p $PIDFILE $DAEMON
+    log_end_msg $?
+    rm -f "$PIDFILE"
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status_of_proc -p "$PIDFILE" "$PROG" "$SHORTNAME"
+        RETVAL=$?
+        ;;
+    restart | force-reload)
+        stop
+        sleep 3
+        start
+        ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|force-reload|status}"
+    RETVAL=3
+esac
+
+exit $RETVAL

--- a/packaging/debian/replace.properties
+++ b/packaging/debian/replace.properties
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DBUSER=cloud
+DBPW=cloud
+DBROOTPW=
+MSLOG=vmops.log
+APISERVERLOG=api.log
+DBHOST=localhost
+COMPONENTS-SPEC=components-premium.xml
+REMOTEHOST=localhost
+AGENTCLASSPATH=
+AGENTLOG=/var/log/cloudstack/agent/agent.log
+AGENTLOGDIR=/var/log/cloudstack/agent/
+AGENTSYSCONFDIR=/etc/cloudstack/agent
+APISERVERLOG=/var/log/cloudstack/management/apilog.log
+BINDIR=/usr/bin
+COMMONLIBDIR=/usr/share/cloudstack-common
+CONFIGUREVARS=
+DEPSCLASSPATH=/usr/share/tomcat6/bin/bootstrap.jar:/usr/share/tomcat6/bin/tomcat-juli.jar
+DOCDIR=
+IPALOCATORLOG=/var/log/cloudstack/management/ipallocator.log
+JAVADIR=/usr/share/cloudstack-management/webapps/client/WEB-INF/lib
+LIBEXECDIR=/usr/libexec
+LOCKDIR=/var/lock
+MSCLASSPATH=
+MSCONF=/etc/cloudstack/management
+MSENVIRON=/usr/share/cloudstack-management
+MSLOG=/var/log/cloudstack/management/management-server.log
+MSLOGDIR=/var/log/cloudstack/management/
+MSMNTDIR=/var/lib/cloudstack/mnt
+MSUSER=cloud
+PIDDIR=/var/run
+PLUGINJAVADIR=
+PREMIUMJAVADIR=
+PYTHONDIR=/usr/lib/python2.6/site-packages/
+SERVERSYSCONFDIR=/etc/cloudstack/server
+SETUPDATADIR=/usr/share/cloudstack-management/setup
+SYSCONFDIR=/etc
+SYSTEMCLASSPATH=
+SYSTEMJARS=
+USAGECLASSPATH=
+USAGELOG=/var/log/cloudstack/usage/usage.log
+USAGESYSCONFDIR=/etc/cloudstack/usage
+PACKAGE=cloudstack

--- a/packaging/fedora20/cloud-agent.rc
+++ b/packaging/fedora20/cloud-agent.rc
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# chkconfig: 35 99 10
+# description: Cloud Agent
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# WARNING: if this script is changed, then all other initscripts MUST BE changed to match it as well
+
+. /etc/rc.d/init.d/functions
+
+# set environment variables
+
+SHORTNAME=$(basename $0 | sed -e 's/^[SK][0-9][0-9]//')
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+LOGDIR=/var/log/cloudstack/agent
+LOGFILE=${LOGDIR}/agent.log
+PROGNAME="Cloud Agent"
+CLASS="com.cloud.agent.AgentShell"
+JSVC=`which jsvc 2>/dev/null`;
+
+# exit if we don't find jsvc
+if [ -z "$JSVC" ]; then
+    echo no jsvc found in path;
+    exit 1;
+fi
+
+unset OPTIONS
+[ -r /etc/sysconfig/"$SHORTNAME" ] && source /etc/sysconfig/"$SHORTNAME"
+
+# The first existing directory is used for JAVA_HOME (if JAVA_HOME is not defined in $DEFAULT)
+JDK_DIRS="/usr/lib/jvm/jre /usr/lib/jvm/java-7-openjdk /usr/lib/jvm/java-7-openjdk-i386 /usr/lib/jvm/java-7-openjdk-amd64 /usr/lib/jvm/java-6-openjdk /usr/lib/jvm/java-6-openjdk-i386 /usr/lib/jvm/java-6-openjdk-amd64 /usr/lib/jvm/java-6-sun"
+
+for jdir in $JDK_DIRS; do
+    if [ -r "$jdir/bin/java" -a -z "${JAVA_HOME}" ]; then
+        JAVA_HOME="$jdir"
+    fi
+done
+export JAVA_HOME
+
+ACP=`ls /usr/share/cloudstack-agent/lib/*.jar | tr '\n' ':' | sed s'/.$//'`
+PCP=`ls /usr/share/cloudstack-agent/plugins/*.jar 2>/dev/null | tr '\n' ':' | sed s'/.$//'`
+
+# We need to append the JSVC daemon JAR to the classpath
+# AgentShell implements the JSVC daemon methods
+export CLASSPATH="/usr/share/java/commons-daemon.jar:$ACP:$PCP:/etc/cloudstack/agent:/usr/share/cloudstack-common/scripts"
+
+start() {
+    echo -n $"Starting $PROGNAME: "
+    if hostname --fqdn >/dev/null 2>&1 ; then
+        $JSVC -Xms256m -Xmx2048m -cp "$CLASSPATH" -pidfile "$PIDFILE" \
+            -errfile $LOGDIR/cloudstack-agent.err -outfile $LOGDIR/cloudstack-agent.out $CLASS
+        RETVAL=$?
+        echo
+    else
+        failure
+        echo
+        echo The host name does not resolve properly to an IP address.  Cannot start "$PROGNAME". > /dev/stderr
+        RETVAL=9
+    fi
+    [ $RETVAL = 0 ] && touch ${LOCKFILE}
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping $PROGNAME: "
+    $JSVC -pidfile "$PIDFILE" -stop $CLASS
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && rm -f ${LOCKFILE} ${PIDFILE}
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status -p ${PIDFILE} $SHORTNAME
+        RETVAL=$?
+        ;;
+    restart)
+        stop
+        sleep 3
+        start
+        ;;
+    condrestart)
+        if status -p ${PIDFILE} $SHORTNAME >&/dev/null; then
+            stop
+            sleep 3
+            start
+        fi
+        ;;
+    *)
+    echo $"Usage: $SHORTNAME {start|stop|restart|condrestart|status|help}"
+    RETVAL=3
+esac
+
+exit $RETVAL

--- a/packaging/fedora20/cloud-ipallocator.rc
+++ b/packaging/fedora20/cloud-ipallocator.rc
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# chkconfig: 35 99 10
+# description: Cloud Agent
+
+# WARNING: if this script is changed, then all other initscripts MUST BE changed to match it as well
+
+. /etc/rc.d/init.d/functions
+
+# set environment variables
+
+SHORTNAME="$(basename $(readlink -f $0))"
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+LOGFILE=/var/log/cloudstack/ipallocator/ipallocator.log
+PROGNAME="External IPAllocator"
+
+unset OPTIONS
+[ -r /etc/sysconfig/"$SHORTNAME" ] && source /etc/sysconfig/"$SHORTNAME"
+DAEMONIZE=/usr/bin/cloud-daemonize
+PROG=/usr/bin/cloud-external-ipallocator.py
+OPTIONS=8083
+
+start() {
+        echo -n $"Starting $PROGNAME: "
+	if hostname --fqdn >/dev/null 2>&1 ; then
+		daemon --check=$SHORTNAME --pidfile=${PIDFILE} "$DAEMONIZE" \
+			-n "$SHORTNAME" -p "$PIDFILE" -l "$LOGFILE" "$PROG" $OPTIONS
+		RETVAL=$?
+		echo
+	else
+		failure
+		echo
+		echo The host name does not resolve properly to an IP address.  Cannot start "$PROGNAME". > /dev/stderr
+		RETVAL=9
+	fi
+	[ $RETVAL = 0 ] && touch ${LOCKFILE}
+	return $RETVAL
+}
+
+stop() {
+	echo -n $"Stopping $PROGNAME: "
+	killproc -p ${PIDFILE} $SHORTNAME # -d 10 $SHORTNAME
+	RETVAL=$?
+	echo
+	[ $RETVAL = 0 ] && rm -f ${LOCKFILE} ${PIDFILE}
+}
+
+
+# See how we were called.
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  status)
+        status -p ${PIDFILE} $SHORTNAME
+	RETVAL=$?
+	;;
+  restart)
+	stop
+	sleep 3
+	start
+	;;
+  condrestart)
+	if status -p ${PIDFILE} $SHORTNAME >&/dev/null; then
+		stop
+		sleep 3
+		start
+	fi
+	;;
+  *)
+	echo $"Usage: $SHORTNAME {start|stop|restart|condrestart|status|help}"
+	RETVAL=3
+esac
+
+exit $RETVAL
+

--- a/packaging/fedora20/cloud-management.rc
+++ b/packaging/fedora20/cloud-management.rc
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# cloudstack-management      This shell script takes care of starting and stopping Tomcat
+#
+# chkconfig: - 80 20
+#
+### BEGIN INIT INFO
+# Provides: tomcat6
+# Required-Start: $network $syslog
+# Required-Stop: $network $syslog
+# Default-Start:
+# Default-Stop:
+# Description: Release implementation for Servlet 2.5 and JSP 2.1
+# Short-Description: start and stop tomcat
+### END INIT INFO
+#
+# - originally written by Henri Gomez, Keith Irwin, and Nicolas Mailhot
+# - heavily rewritten by Deepak Bhole and Jason Corley
+#
+
+if [ -r /etc/rc.d/init.d/functions ]; then
+    . /etc/rc.d/init.d/functions
+fi
+if [ -r /lib/lsb/init-functions ]; then
+    . /lib/lsb/init-functions
+fi
+
+
+NAME="$(basename $(readlink -f $0))"
+export SERVICE_NAME="$NAME"
+stop() {
+	SHUTDOWN_WAIT="30"
+	count="0"
+	if [ -f /var/run/${NAME}.pid ]; then
+		pid=`cat /var/run/${NAME}.pid`
+		kill $pid &>/dev/null
+		until [ "$(ps --pid $pid | grep -c $pid)" -eq "0" ] || \
+			[ "$count" -gt "$SHUTDOWN_WAIT" ]
+		do
+			sleep 1
+			let count="${count}+1"
+		done
+		if [ "$(ps --pid $pid | grep -c $pid)" -eq "0" ]; then
+			log_success_msg "Stopping ${NAME}:"
+			rm -f /var/run/${NAME}.pid
+			rm -f /var/lock/subsys/${NAME}
+		else
+			log_failure_msg "Stopping ${NAME}:"
+		fi
+	else
+		echo "Cannot find PID file of ${NAME}"
+		log_failure_msg "Stopping ${NAME}:"
+	fi
+}
+
+set_ulimit() {
+    fd_limit=`ulimit -n`
+    if [ "$fd_limit" != "4096" ]; then
+        user=`whoami`
+        if [ $user == "root" ]; then
+            ulimit -n 4096
+        fi
+    fi
+}
+
+handle_pid_file() {
+     if [ "$1" -ne 0 ] && [ "$1" -ne 3 ]; then
+        echo "The pid file locates at /var/run/${NAME}.pid and lock file at /var/lock/subsys/${NAME}.
+        Starting ${NAME} will take care of them or you can manually clean up."
+    fi
+}
+
+start() {
+    readpath=$(readlink -f $0)
+    source `dirname $readpath`/tomcat.sh
+}
+
+# See how we were called.
+case "$1" in
+    status)
+		status ${NAME}
+		RETVAL=$?
+        handle_pid_file $RETVAL
+		;;
+    stop)
+		stop
+		;;
+    restart)
+		stop
+		set start
+        set_ulimit
+	        start
+		;;
+	*)
+        set_ulimit
+                start
+esac
+
+exit $RETVAL

--- a/packaging/fedora20/cloud-management.sysconfig
+++ b/packaging/fedora20/cloud-management.sysconfig
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This file is loaded in /etc/init.d/vmopsmanagement
+# ATM we only do two things here:
+
+dummy=1 ; export TOMCAT_CFG=/etc/cloudstack/management/tomcat6.conf ; . /etc/cloudstack/management/tomcat6.conf
+#--------------------------
+

--- a/packaging/fedora20/cloud-usage.rc
+++ b/packaging/fedora20/cloud-usage.rc
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+### BEGIN INIT INFO
+# Provides:          cloudstack-usage
+# Required-Start:    $network $local_fs
+# Required-Stop:     $network $local_fs
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Start/stop Apache CloudStack Usage Monitor
+# Description: This scripts Starts/Stops the Apache CloudStack Usage Monitor
+##  The CloudStack Usage Monitor is a part of the Apache CloudStack project and is used
+##  for storing usage statistics from instances.
+## JSVC (Java daemonizing) is used for starting and stopping the usage monitor.
+### END INIT INFO
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+. /etc/rc.d/init.d/functions
+
+SHORTNAME="cloudstack-usage"
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+LOGDIR=/var/log/cloudstack/usage
+LOGFILE=${LOGDIR}/usage.log
+PROGNAME="CloudStack Usage Monitor"
+CLASS="com.cloud.usage.UsageServer"
+PROG="jsvc"
+DAEMON="/usr/bin/jsvc"
+USER=cloud
+
+unset OPTIONS
+[ -r /etc/sysconfig/default/"$SHORTNAME" ] && source /etc/sysconfig/default/"$SHORTNAME"
+
+setJavaHome() {
+  # use $JAVA_HOME if defined
+  if [ -n "$JAVA_HOME" ] ; then
+    return
+  fi
+
+  # try java first
+  java=$(which java 2>/dev/null || :)
+
+  # try javac if java is not found
+  if [ -z "$java" ] ; then
+    java=$(which javac 2>/dev/null || :)
+  fi
+
+  if [ -n "$java" ] ; then
+    JAVA_HOME=$(dirname $(dirname $(readlink -e $java)))
+    export JAVA_HOME
+    return
+  fi
+
+  # didnt find java home. exiting with error
+  exit 1
+}
+
+setJavaHome
+
+SCP=""
+DCP=""
+UCP=`ls /usr/share/cloudstack-usage/cloud-usage-*.jar`":"`ls /usr/share/cloudstack-usage/lib/*.jar | tr '\n' ':'`
+JCP="/usr/share/java/commons-daemon.jar":"/usr/share/java/mysql-connector-java.jar"
+
+# We need to append the JSVC daemon  and mysql-connector JAR to the classpath
+# AgentShell implements the JSVC daemon methods
+export CLASSPATH="$SCP:$DCP:$UCP:$JCP:/etc/cloudstack/usage"
+
+start() {
+    if [ -s "$PIDFILE" ] && kill -0 $(cat "$PIDFILE") >/dev/null 2>&1; then
+        echo "$PROGNAME apparently already running"
+        exit 0
+    fi
+
+    if hostname --fqdn >/dev/null 2>&1 ; then
+        true
+    else
+        echo "The host name does not resolve properly to an IP address. Cannot start $PROGNAME"
+        exit 1
+    fi
+
+    echo -n "Starting $PROGNAME" "$SHORTNAME"
+
+    if daemon --pidfile $PIDFILE $DAEMON -home "$JAVA_HOME" -cp "$CLASSPATH" -pidfile "$PIDFILE" -user "$USER" \
+      -errfile $LOGDIR/cloudstack-usage.err -outfile $LOGDIR/cloudstack-usage.out -Dpid=$$ $CLASS
+        RETVAL=$?
+    then
+        rc=0
+        sleep 1
+        if ! kill -0 $(cat "$PIDFILE") >/dev/null 2>&1; then
+            failure
+            rc=1
+        fi
+    else
+        rc=1
+    fi
+
+    if [ $rc -eq 0 ]; then
+        success
+    else
+        failure
+        rm -f "$PIDFILE"
+    fi
+    echo
+}
+
+stop() {
+    echo -n "Stopping $PROGNAME" "$SHORTNAME"
+    killproc -p $PIDFILE $DAEMON
+    if [ "$?" -eq 0 ]; then
+        success
+    else
+        failure
+    fi
+    rm -f "$PIDFILE"
+    echo
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status -p $PIDFILE $SHORTNAME
+        RETVAL=$?
+        ;;
+    restart | force-reload)
+        stop
+        sleep 3
+        start
+        ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|force-reload|status}"
+    RETVAL=3
+esac
+
+exit $RETVAL
+

--- a/packaging/fedora20/cloud.spec
+++ b/packaging/fedora20/cloud.spec
@@ -1,0 +1,648 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+%define __os_install_post %{nil}
+%global debug_package %{nil}
+
+# DISABLE the post-percentinstall java repacking and line number stripping
+# we need to find a way to just disable the java repacking and line number stripping, but not the autodeps
+
+Name:      cloudstack
+Summary:   CloudStack IaaS Platform
+#http://fedoraproject.org/wiki/PackageNamingGuidelines#Pre-Release_packages
+%if "%{?_prerelease}" != ""
+%define _maventag %{_ver}-SNAPSHOT
+Release:   %{_rel}%{dist}
+%else
+%define _maventag %{_ver}
+Release:   %{_rel}%{dist}
+%endif
+
+%{!?python_sitearch: %define python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
+
+Version:   %{_ver}
+License:   ASL 2.0
+Vendor:    Apache CloudStack <dev@cloudstack.apache.org>
+Packager:  Apache CloudStack <dev@cloudstack.apache.org>
+Group:     System Environment/Libraries
+# FIXME do groups for every single one of the subpackages
+Source0:   %{name}-%{_maventag}.tgz
+BuildRoot: %{_tmppath}/%{name}-%{_maventag}-%{release}-build
+
+BuildRequires: java-1.7.0-openjdk-devel
+BuildRequires: tomcat
+BuildRequires: ws-commons-util
+BuildRequires: jpackage-utils
+BuildRequires: gcc
+BuildRequires: glibc-devel
+BuildRequires: /usr/bin/mkisofs
+BuildRequires: MySQL-python
+#BuildRequires: maven => 3.0.0
+
+%description
+CloudStack is a highly-scalable elastic, open source,
+intelligent IaaS cloud implementation.
+
+%package management
+Summary:   CloudStack management server UI
+Requires: tomcat
+Requires: java-1.7.0-openjdk
+Requires: python
+Requires: bash
+Requires: bzip2
+Requires: gzip
+Requires: unzip
+Requires: /sbin/mount.nfs
+Requires: openssh-clients
+Requires: nfs-utils
+Requires: wget
+Requires: mysql
+Requires: mysql-connector-java
+Requires: ws-commons-util
+Requires: jpackage-utils
+Requires: sudo
+Requires: /sbin/service
+Requires: /sbin/chkconfig
+Requires: /usr/bin/ssh-keygen
+Requires: mkisofs
+Requires: MySQL-python
+Requires: python-paramiko
+Requires: ipmitool
+Requires: %{name}-common = %{_ver}
+Obsoletes: cloud-client < 4.1.0
+Obsoletes: cloud-client-ui < 4.1.0
+Obsoletes: cloud-server < 4.1.0
+Obsoletes: cloud-test < 4.1.0
+Provides:  cloud-client
+Group:     System Environment/Libraries
+%description management
+The CloudStack management server is the central point of coordination,
+management, and intelligence in CloudStack.  
+
+%package common
+Summary: Apache CloudStack common files and scripts
+Requires: python
+Obsoletes: cloud-test < 4.1.0 
+Obsoletes: cloud-scripts < 4.1.0
+Obsoletes: cloud-utils < 4.1.0
+Obsoletes: cloud-core < 4.1.0
+Obsoletes: cloud-deps < 4.1.0
+Obsoletes: cloud-python < 4.1.0
+Obsoletes: cloud-setup < 4.1.0
+Obsoletes: cloud-cli < 4.1.0
+Obsoletes: cloud-daemonize < 4.1.0
+Group:   System Environment/Libraries
+%description common
+The Apache CloudStack files shared between agent and management server
+
+%package agent
+Summary: CloudStack Agent for KVM hypervisors
+Requires: openssh-clients
+Requires: java-1.7.0-openjdk
+Requires: %{name}-common = %{_ver}
+Requires: libvirt
+Requires: bridge-utils
+Requires: ebtables
+Requires: iptables
+Requires: ethtool
+Requires: vconfig
+Requires: ipset
+Requires: jsvc
+Requires: jakarta-commons-daemon
+Requires: jakarta-commons-daemon-jsvc
+Requires: perl
+Requires: libvirt-python
+Requires: qemu-img
+Requires: qemu-kvm
+Requires: libcgroup-tools
+Requires: net-tools
+Provides: cloud-agent
+Obsoletes: cloud-agent < 4.1.0
+Obsoletes: cloud-agent-libs < 4.1.0
+Obsoletes: cloud-test < 4.1.0
+Group: System Environment/Libraries
+%description agent
+The CloudStack agent for KVM hypervisors
+
+%package baremetal-agent
+Summary: CloudStack baremetal agent
+Requires: tftp-server
+Requires: xinetd
+Requires: syslinux
+Requires: chkconfig
+Requires: dhcp
+Requires: httpd
+Group:     System Environment/Libraries
+%description baremetal-agent
+The CloudStack baremetal agent
+
+%package usage
+Summary: CloudStack Usage calculation server
+Requires: java-1.7.0-openjdk
+Requires: jsvc
+Requires: jakarta-commons-daemon
+Requires: jakarta-commons-daemon-jsvc
+Group: System Environment/Libraries
+Obsoletes: cloud-usage < 4.1.0
+Provides: cloud-usage 
+%description usage
+The CloudStack usage calculation service
+
+%package cli
+Summary: Apache CloudStack CLI
+Provides: python-cloudmonkey
+Provides: python-marvin
+Group: System Environment/Libraries
+%description cli
+Apache CloudStack command line interface
+
+%if "%{_ossnoss}" == "noredist"
+%package mysql-ha
+Summary: Apache CloudStack Balancing Strategy for MySQL
+Requires: mysql-connector-java
+Requires: tomcat
+Group: System Environmnet/Libraries
+%description mysql-ha
+Apache CloudStack Balancing Strategy for MySQL
+
+%endif
+
+%prep
+echo Doing CloudStack build
+
+%setup -q -n %{name}-%{_maventag}
+
+%build
+
+cp packaging/centos63/replace.properties build/replace.properties
+echo VERSION=%{_maventag} >> build/replace.properties
+echo PACKAGE=%{name} >> build/replace.properties
+touch build/gitrev.txt
+echo $(git rev-parse HEAD) > build/gitrev.txt
+
+if [ "%{_ossnoss}" == "NOREDIST" -o "%{_ossnoss}" == "noredist" ] ; then
+   echo "Executing mvn packaging with non-redistributable libraries"
+   if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then 
+      echo "Executing mvn noredist packaging with simulator ..."
+      mvn -Psystemvm -Dnoredist -Dsimulator clean package
+   else
+      echo "Executing mvn noredist packaging without simulator..."
+      mvn -Psystemvm -Dnoredist clean package
+   fi
+else
+   if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then 
+      echo "Executing mvn default packaging simulator ..."
+      mvn -Psystemvm -Dsimulator clean package
+   else
+      echo "Executing mvn default packaging without simulator ..."
+      mvn -Psystemvm clean package
+   fi
+fi 
+
+%install
+[ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
+# Common directories
+mkdir -p ${RPM_BUILD_ROOT}%{_bindir}
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/ipallocator
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
+mkdir -p ${RPM_BUILD_ROOT}%{_initrddir}
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/sysconfig
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/profile.d
+
+# Common
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms
+mkdir -p ${RPM_BUILD_ROOT}%{python_sitearch}/
+mkdir -p ${RPM_BUILD_ROOT}%/usr/bin
+cp -r scripts/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+install -D systemvm/dist/systemvm.iso ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms/systemvm.iso
+install -D systemvm/dist/systemvm.zip ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms/systemvm.zip
+install python/lib/cloud_utils.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloud_utils.py
+cp -r python/lib/cloudutils ${RPM_BUILD_ROOT}%{python_sitearch}/
+python -m py_compile ${RPM_BUILD_ROOT}%{python_sitearch}/cloud_utils.py
+python -m compileall ${RPM_BUILD_ROOT}%{python_sitearch}/cloudutils
+cp build/gitrev.txt ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+cp packaging/centos63/cloudstack-sccs ${RPM_BUILD_ROOT}/usr/bin
+ 
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts/network/cisco
+cp -r plugins/network-elements/cisco-vnmc/scripts/network/cisco/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts/network/cisco
+
+# Management
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management
+
+# Specific for tomcat
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+ln -sf /usr/share/tomcat/bin ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/bin
+ln -sf /etc/%{name}/management ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/conf
+ln -sf /usr/share/tomcat/lib ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/lib
+ln -sf /var/log/%{name}/management ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/logs
+ln -sf /var/cache/%{name}/management/temp ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/temp
+ln -sf /var/cache/%{name}/management/work ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/work
+
+/bin/touch ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management/catalina.out
+
+install -D client/target/utilities/bin/cloud-migrate-databases ${RPM_BUILD_ROOT}%{_bindir}/%{name}-migrate-databases
+install -D client/target/utilities/bin/cloud-set-guest-password ${RPM_BUILD_ROOT}%{_bindir}/%{name}-set-guest-password
+install -D client/target/utilities/bin/cloud-set-guest-sshkey ${RPM_BUILD_ROOT}%{_bindir}/%{name}-set-guest-sshkey
+install -D client/target/utilities/bin/cloud-setup-databases ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-databases
+install -D client/target/utilities/bin/cloud-setup-encryption ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-encryption
+install -D client/target/utilities/bin/cloud-setup-management ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-management
+install -D client/target/utilities/bin/cloud-setup-baremetal ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-baremetal
+install -D client/target/utilities/bin/cloud-sysvmadm ${RPM_BUILD_ROOT}%{_bindir}/%{name}-sysvmadm
+install -D client/target/utilities/bin/cloud-update-xenserver-licenses ${RPM_BUILD_ROOT}%{_bindir}/%{name}-update-xenserver-licenses
+
+cp -r client/target/utilities/scripts/db/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup
+cp -r client/target/cloud-client-ui-%{_maventag}/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client
+
+# Don't package the scripts in the management webapp
+rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/scripts
+rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/vms
+
+for name in db.properties log4j-cloud.xml tomcat6-nonssl.conf tomcat6-ssl.conf server-ssl.xml server-nonssl.xml \
+            catalina.policy catalina.properties classpath.conf tomcat-users.xml web.xml environment.properties java.security.ciphers ; do
+  mv ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/$name \
+    ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/$name
+done
+
+ln -s %{_sysconfdir}/%{name}/management/log4j-cloud.xml \
+    ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/log4j-cloud.xml
+
+mv ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/context.xml \
+    ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+
+install python/bindir/cloud-external-ipallocator.py ${RPM_BUILD_ROOT}%{_bindir}/%{name}-external-ipallocator.py
+install -D client/target/pythonlibs/jasypt-1.9.2.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/lib/jasypt-1.9.2.jar
+
+install -D packaging/centos63/cloud-ipallocator.rc ${RPM_BUILD_ROOT}%{_initrddir}/%{name}-ipallocator
+install -D packaging/centos63/cloud-management.rc ${RPM_BUILD_ROOT}%{_initrddir}/%{name}-management
+install -D packaging/centos63/cloud-management.sysconfig ${RPM_BUILD_ROOT}%{_sysconfdir}/sysconfig/%{name}-management
+install -D packaging/centos63/tomcat.sh ${RPM_BUILD_ROOT}%{_initrddir}/tomcat.sh
+
+chmod 440 ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+
+# KVM Agent
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/plugins
+install -D packaging/centos63/cloud-agent.rc ${RPM_BUILD_ROOT}%{_sysconfdir}/init.d/%{name}-agent
+install -D agent/target/transformed/agent.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/agent.properties
+install -D agent/target/transformed/environment.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/environment.properties
+install -D agent/target/transformed/log4j-cloud.xml ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/log4j-cloud.xml
+install -D agent/target/transformed/cloud-setup-agent ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-agent
+install -D agent/target/transformed/cloudstack-agent-upgrade ${RPM_BUILD_ROOT}%{_bindir}/%{name}-agent-upgrade
+install -D agent/target/transformed/libvirtqemuhook ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib/libvirtqemuhook
+install -D agent/target/transformed/cloud-ssh ${RPM_BUILD_ROOT}%{_bindir}/%{name}-ssh
+install -D agent/target/transformed/cloudstack-agent-profile.sh ${RPM_BUILD_ROOT}%{_sysconfdir}/profile.d/%{name}-agent-profile.sh
+install -D agent/target/transformed/cloudstack-agent.logrotate ${RPM_BUILD_ROOT}%{_sysconfdir}/logrotate.d/%{name}-agent
+install -D plugins/hypervisors/kvm/target/cloud-plugin-hypervisor-kvm-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%name-agent/lib/cloud-plugin-hypervisor-kvm-%{_maventag}.jar
+cp plugins/hypervisors/kvm/target/dependencies/*  ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib
+
+# Usage server
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib
+install -D usage/target/cloud-usage-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/cloud-usage-%{_maventag}.jar
+install -D usage/target/transformed/db.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage/db.properties
+install -D usage/target/transformed/log4j-cloud_usage.xml ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage/log4j-cloud.xml
+cp usage/target/dependencies/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib/
+install -D packaging/centos63/cloud-usage.rc ${RPM_BUILD_ROOT}/%{_sysconfdir}/init.d/%{name}-usage
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/usage/
+
+# CLI
+cp -r cloud-cli/cloudtool ${RPM_BUILD_ROOT}%{python_sitearch}/
+install cloud-cli/cloudapis/cloud.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloudapis.py
+
+# MYSQL HA
+if [ "x%{_ossnoss}" == "xnoredist" ] ; then
+  mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-mysql-ha/lib
+  cp -r plugins/database/mysql-ha/target/cloud-plugin-database-mysqlha-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-mysql-ha/lib
+fi
+
+#License files from whisker
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-management-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-management-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-common-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-common-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-agent-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-agent-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-cli-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-cli-%{version}/LICENSE
+if [ "x%{_ossnoss}" == "xnoredist" ] ; then
+  install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-mysql-ha-%{version}/LICENSE
+  install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-mysql-ha-%{version}/NOTICE
+fi
+
+%clean
+[ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
+
+%preun management
+/sbin/service cloudstack-management stop || true
+if [ "$1" == "0" ] ; then
+    /sbin/chkconfig --del cloudstack-management  > /dev/null 2>&1 || true
+    /sbin/service cloudstack-management stop > /dev/null 2>&1 || true
+fi
+
+%pre management
+id cloud > /dev/null 2>&1 || /usr/sbin/useradd -M -c "CloudStack unprivileged user" \
+     -r -s /bin/sh -d %{_localstatedir}/cloudstack/management cloud|| true
+
+# set max file descriptors for cloud user to 4096
+sed -i /"cloud hard nofile"/d /etc/security/limits.conf
+sed -i /"cloud soft nofile"/d /etc/security/limits.conf
+echo "cloud hard nofile 4096" >> /etc/security/limits.conf
+echo "cloud soft nofile 4096" >> /etc/security/limits.conf
+rm -rf %{_localstatedir}/cache/cloud
+rm -rf %{_localstatedir}/cache/cloudstack
+# user harcoded here, also hardcoded on wscript
+
+# save old configs if they exist (for upgrade). Otherwise we may lose them
+# when the old packages are erased. There are a lot of properties files here.
+if [ -d "%{_sysconfdir}/cloud" ] ; then
+    mv %{_sysconfdir}/cloud %{_sysconfdir}/cloud.rpmsave
+fi
+
+%post management
+if [ "$1" == "1" ] ; then
+    /sbin/chkconfig --add cloudstack-management > /dev/null 2>&1 || true
+    /sbin/chkconfig --level 345 cloudstack-management on > /dev/null 2>&1 || true
+fi
+
+if [ ! -f %{_datadir}/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util ] ; then
+    echo Please download vhd-util from http://download.cloud.com.s3.amazonaws.com/tools/vhd-util and put it in 
+    echo %{_datadir}/cloudstack-common/scripts/vm/hypervisor/xenserver/
+fi
+
+# change cloud user's home to 4.1+ version if needed. Would do this via 'usermod', but it
+# requires that cloud user not be in use, so RPM could not be installed while management is running
+if getent passwd cloud | grep -q /var/lib/cloud; then 
+    sed -i 's/\/var\/lib\/cloud\/management/\/var\/cloudstack\/management/g' /etc/passwd
+fi
+
+# if saved configs from upgrade exist, copy them over
+if [ -f "%{_sysconfdir}/cloud.rpmsave/management/db.properties" ]; then
+    mv %{_sysconfdir}/%{name}/management/db.properties %{_sysconfdir}/%{name}/management/db.properties.rpmnew
+    cp -p %{_sysconfdir}/cloud.rpmsave/management/db.properties %{_sysconfdir}/%{name}/management
+    if [ -f "%{_sysconfdir}/cloud.rpmsave/management/key" ]; then    
+        cp -p %{_sysconfdir}/cloud.rpmsave/management/key %{_sysconfdir}/%{name}/management
+    fi
+    # make sure we only do this on the first install of this RPM, don't want to overwrite on a reinstall
+    mv %{_sysconfdir}/cloud.rpmsave/management/db.properties %{_sysconfdir}/cloud.rpmsave/management/db.properties.rpmsave
+fi
+
+# Choose server.xml and tomcat.conf links based on old config, if exists
+serverxml=%{_sysconfdir}/%{name}/management/server.xml
+oldserverxml=%{_sysconfdir}/cloud.rpmsave/management/server.xml
+if [ -f $oldserverxml ] || [ -L $oldserverxml ]; then
+    if stat -c %N $oldserverxml| grep -q server-ssl ; then
+        if [ -f $serverxml ] || [ -L $serverxml ]; then rm -f $serverxml; fi
+        ln -s %{_sysconfdir}/%{name}/management/server-ssl.xml $serverxml
+        echo Please verify the server.xml in saved folder, and make the required changes manually , saved folder available at $oldserverxml
+    else
+        if [ -f $serverxml ] || [ -L $serverxml ]; then rm -f $serverxml; fi
+        ln -s %{_sysconfdir}/%{name}/management/server-nonssl.xml $serverxml
+        echo Please verify the server.xml in saved folder, and make the required changes manually , saved folder available at $oldserverxml
+
+    fi
+else
+    echo "Unable to determine ssl settings for server.xml, please run cloudstack-setup-management manually"
+fi
+
+
+tomcatconf=%{_sysconfdir}/%{name}/management/tomcat6.conf
+oldtomcatconf=%{_sysconfdir}/cloud.rpmsave/management/tomcat6.conf
+if [ -f $oldtomcatconf ] || [ -L $oldtomcatconf ] ; then
+    if stat -c %N $oldtomcatconf| grep -q tomcat6-ssl ; then
+        if [ -f $tomcatconf ] || [ -L $tomcatconf ]; then rm -f $tomcatconf; fi
+        ln -s %{_sysconfdir}/%{name}/management/tomcat6-ssl.conf $tomcatconf
+        echo Please verify the tomcat6.conf in saved folder, and make the required changes manually , saved folder available at $oldtomcatconf
+    else
+        if [ -f $tomcatconf ] || [ -L $tomcatconf ]; then rm -f $tomcatconf; fi
+        ln -s %{_sysconfdir}/%{name}/management/tomcat6-nonssl.conf $tomcatconf
+        echo Please verify the tomcat6.conf in saved folder, and make the required changes manually , saved folder available at $oldtomcatconf
+    fi
+else
+    echo "Unable to determine ssl settings for tomcat.conf, please run cloudstack-setup-management manually"
+fi
+
+if [ -f "%{_sysconfdir}/cloud.rpmsave/management/cloud.keystore" ]; then
+    cp -p %{_sysconfdir}/cloud.rpmsave/management/cloud.keystore %{_sysconfdir}/%{name}/management/cloudmanagementserver.keystore
+    # make sure we only do this on the first install of this RPM, don't want to overwrite on a reinstall
+    mv %{_sysconfdir}/cloud.rpmsave/management/cloud.keystore %{_sysconfdir}/cloud.rpmsave/management/cloud.keystore.rpmsave
+fi
+
+%preun agent
+/sbin/service cloudstack-agent stop || true
+if [ "$1" == "0" ] ; then
+    /sbin/chkconfig --del cloudstack-agent > /dev/null 2>&1 || true
+    /sbin/service cloudstack-agent stop > /dev/null 2>&1 || true
+fi
+
+%pre agent
+
+# save old configs if they exist (for upgrade). Otherwise we may lose them
+# when the old packages are erased. There are a lot of properties files here.
+if [ -d "%{_sysconfdir}/cloud" ] ; then
+    mv %{_sysconfdir}/cloud %{_sysconfdir}/cloud.rpmsave
+fi
+
+%post agent
+if [ "$1" == "1" ] ; then
+    echo "Running %{_bindir}/%{name}-agent-upgrade to update bridge name for upgrade from CloudStack 4.0.x (and before) to CloudStack 4.1 (and later)"
+    %{_bindir}/%{name}-agent-upgrade
+    if [ ! -d %{_sysconfdir}/libvirt/hooks ] ; then
+        mkdir %{_sysconfdir}/libvirt/hooks
+    fi
+    cp -a ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib/libvirtqemuhook %{_sysconfdir}/libvirt/hooks/qemu
+    /sbin/service libvirtd restart
+    /sbin/chkconfig --add cloudstack-agent > /dev/null 2>&1 || true
+    /sbin/chkconfig --level 345 cloudstack-agent on > /dev/null 2>&1 || true
+fi
+
+# if saved configs from upgrade exist, copy them over
+if [ -f "%{_sysconfdir}/cloud.rpmsave/agent/agent.properties" ]; then
+    mv %{_sysconfdir}/%{name}/agent/agent.properties  %{_sysconfdir}/%{name}/agent/agent.properties.rpmnew
+    cp -p %{_sysconfdir}/cloud.rpmsave/agent/agent.properties %{_sysconfdir}/%{name}/agent
+    # make sure we only do this on the first install of this RPM, don't want to overwrite on a reinstall
+    mv %{_sysconfdir}/cloud.rpmsave/agent/agent.properties %{_sysconfdir}/cloud.rpmsave/agent/agent.properties.rpmsave
+fi
+
+%preun usage
+/sbin/service cloudstack-usage stop || true
+if [ "$1" == "0" ] ; then
+    /sbin/chkconfig --del cloudstack-usage > /dev/null 2>&1 || true
+    /sbin/service cloudstack-usage stop > /dev/null 2>&1 || true
+fi
+
+%post usage
+if [ -f "%{_sysconfdir}/%{name}/management/db.properties" ]; then
+    echo Replacing db.properties with management server db.properties
+    rm -f %{_sysconfdir}/%{name}/usage/db.properties
+    ln -s %{_sysconfdir}/%{name}/management/db.properties %{_sysconfdir}/%{name}/usage/db.properties
+    /sbin/chkconfig --add cloudstack-usage > /dev/null 2>&1 || true
+    /sbin/chkconfig --level 345 cloudstack-usage on > /dev/null 2>&1 || true
+fi
+
+if [ -f "%{_sysconfdir}/%{name}/management/key" ]; then
+    echo Replacing key with management server key
+    rm -f %{_sysconfdir}/%{name}/usage/key
+    ln -s %{_sysconfdir}/%{name}/management/key %{_sysconfdir}/%{name}/usage/key
+fi
+
+#No default permission as the permission setup is complex
+%files management
+%defattr(-,root,root,-)
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina/localhost
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina/localhost/client
+%dir %{_datadir}/%{name}-management
+%dir %attr(0770,root,cloud) %{_localstatedir}/%{name}/mnt
+%dir %attr(0770,cloud,cloud) %{_localstatedir}/%{name}/management
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/work
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/temp
+%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/management
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}-management
+%config(noreplace) %attr(0640,root,cloud) %{_sysconfdir}/%{name}/management/db.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/log4j-cloud.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/tomcat6-nonssl.conf
+%config(noreplace) %{_sysconfdir}/%{name}/management/tomcat6-ssl.conf
+%config(noreplace) %{_sysconfdir}/%{name}/management/Catalina/localhost/client/context.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/catalina.policy
+%config(noreplace) %{_sysconfdir}/%{name}/management/catalina.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/classpath.conf
+%config(noreplace) %{_sysconfdir}/%{name}/management/server-nonssl.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/server-ssl.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/tomcat-users.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/web.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/environment.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/java.security.ciphers
+%config(noreplace) %{_sysconfdir}/%{name}/management/commons-logging.properties
+%attr(0755,root,root) %{_initrddir}/%{name}-management
+%attr(0755,root,root) %{_initrddir}/tomcat.sh
+
+%attr(0755,root,root) %{_bindir}/%{name}-setup-management
+%attr(0755,root,root) %{_bindir}/%{name}-update-xenserver-licenses
+%{_datadir}/%{name}-management/webapps
+%{_datadir}/%{name}-management/bin
+%{_datadir}/%{name}-management/conf
+%{_datadir}/%{name}-management/lib
+%{_datadir}/%{name}-management/logs
+%{_datadir}/%{name}-management/temp
+%{_datadir}/%{name}-management/work
+%attr(0755,root,root) %{_bindir}/%{name}-setup-databases
+%attr(0755,root,root) %{_bindir}/%{name}-migrate-databases
+%attr(0755,root,root) %{_bindir}/%{name}-set-guest-password
+%attr(0755,root,root) %{_bindir}/%{name}-set-guest-sshkey
+%attr(0755,root,root) %{_bindir}/%{name}-sysvmadm
+%attr(0755,root,root) %{_bindir}/%{name}-setup-encryption
+%{_datadir}/%{name}-management/setup/*.sql
+%{_datadir}/%{name}-management/setup/db/*.sql
+%{_datadir}/%{name}-management/setup/*.sh
+%{_datadir}/%{name}-management/setup/server-setup.xml
+%attr(0755,root,root) %{_bindir}/%{name}-external-ipallocator.py
+%attr(0755,root,root) %{_initrddir}/%{name}-ipallocator
+%dir %attr(0770,root,root) %{_localstatedir}/log/%{name}/ipallocator
+%{_defaultdocdir}/%{name}-management-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-management-%{version}/NOTICE
+%attr(0644,cloud,cloud) %{_localstatedir}/log/%{name}/management/catalina.out
+
+%files agent
+%attr(0755,root,root) %{_bindir}/%{name}-setup-agent
+%attr(0755,root,root) %{_bindir}/%{name}-agent-upgrade
+%attr(0755,root,root) %{_bindir}/%{name}-ssh
+%attr(0755,root,root) %{_sysconfdir}/init.d/%{name}-agent
+%attr(0644,root,root) %{_sysconfdir}/profile.d/%{name}-agent-profile.sh
+%attr(0644,root,root) %{_sysconfdir}/logrotate.d/%{name}-agent
+%attr(0755,root,root) %{_datadir}/%{name}-common/scripts/network/cisco
+%config(noreplace) %{_sysconfdir}/%{name}/agent
+%dir %{_localstatedir}/log/%{name}/agent
+%attr(0644,root,root) %{_datadir}/%{name}-agent/lib/*.jar
+%attr(0755,root,root) %{_datadir}/%{name}-agent/lib/libvirtqemuhook
+%dir %{_datadir}/%{name}-agent/plugins
+%{_defaultdocdir}/%{name}-agent-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-agent-%{version}/NOTICE
+
+%files common
+%dir %attr(0755,root,root) %{python_sitearch}/cloudutils
+%dir %attr(0755,root,root) %{_datadir}/%{name}-common/vms
+%attr(0755,root,root) %{_datadir}/%{name}-common/scripts
+%attr(0755,root,root) /usr/bin/cloudstack-sccs
+%attr(0644, root, root) %{_datadir}/%{name}-common/vms/systemvm.iso
+%attr(0644, root, root) %{_datadir}/%{name}-common/vms/systemvm.zip
+%attr(0644,root,root) %{python_sitearch}/cloud_utils.py
+%attr(0644,root,root) %{python_sitearch}/cloud_utils.pyc
+%attr(0644,root,root) %{python_sitearch}/cloudutils/*
+%attr(0644, root, root) %{_datadir}/%{name}-common/lib/jasypt-1.9.2.jar
+%{_defaultdocdir}/%{name}-common-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-common-%{version}/NOTICE
+
+%files usage
+%attr(0755,root,root) %{_sysconfdir}/init.d/%{name}-usage
+%attr(0644,root,root) %{_datadir}/%{name}-usage/*.jar
+%attr(0644,root,root) %{_datadir}/%{name}-usage/lib/*.jar
+%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/usage
+%attr(0644,root,root) %{_sysconfdir}/%{name}/usage/db.properties
+%attr(0644,root,root) %{_sysconfdir}/%{name}/usage/log4j-cloud.xml
+%{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+
+%files cli
+%attr(0644,root,root) %{python_sitearch}/cloudapis.py
+%attr(0644,root,root) %{python_sitearch}/cloudtool/__init__.py
+%attr(0644,root,root) %{python_sitearch}/cloudtool/utils.py
+%{_defaultdocdir}/%{name}-cli-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-cli-%{version}/NOTICE
+
+%if "%{_ossnoss}" == "noredist"
+%files mysql-ha
+%defattr(0644,cloud,cloud,0755)
+%attr(0644,root,root) %{_datadir}/%{name}-mysql-ha/lib/*
+%{_defaultdocdir}/%{name}-mysql-ha-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-mysql-ha-%{version}/NOTICE
+%endif
+
+%files baremetal-agent
+%attr(0755,root,root) %{_bindir}/cloudstack-setup-baremetal
+
+%changelog
+* Thu Apr 30 2015 Rohit Yadav <bhaisaab@apache.org> 4.6.0
+- Remove awsapi package
+
+* Fri Jul 04 2014 Hugo Trippaers <hugo@apache.org> 4.5.0
+- Add a package for the mysql ha module
+
+* Wed Oct 03 2012 Hugo Trippaers <hugo@apache.org> 4.1.0
+- new style spec file

--- a/packaging/fedora20/cloudstack-agent.te
+++ b/packaging/fedora20/cloudstack-agent.te
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module cloudstack-agent 1.0;
+
+require {
+	type nfs_t;
+	type system_conf_t;
+	type mount_t;
+	type qemu_t;
+	class file unlink;
+	class filesystem getattr;
+}
+
+#============= mount_t ==============
+allow mount_t system_conf_t:file unlink;
+
+#============= qemu_t ==============
+allow qemu_t nfs_t:filesystem getattr;

--- a/packaging/fedora20/cloudstack-sccs
+++ b/packaging/fedora20/cloudstack-sccs
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cat /usr/share/cloudstack-common/scripts/gitrev.txt

--- a/packaging/fedora20/replace.properties
+++ b/packaging/fedora20/replace.properties
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DBUSER=cloud
+DBPW=cloud
+DBROOTPW=
+MSLOG=vmops.log
+APISERVERLOG=api.log
+DBHOST=localhost
+COMPONENTS-SPEC=components-premium.xml
+REMOTEHOST=localhost
+AGENTCLASSPATH=
+AGENTLOG=/var/log/cloudstack/agent/agent.log
+AGENTLOGDIR=/var/log/cloudstack/agent/
+AGENTSYSCONFDIR=/etc/cloudstack/agent
+APISERVERLOG=/var/log/cloudstack/management/apilog.log
+BINDIR=/usr/bin
+COMMONLIBDIR=/usr/share/cloudstack-common
+CONFIGUREVARS=
+DEPSCLASSPATH=
+DOCDIR=
+IPALOCATORLOG=/var/log/cloudstack/management/ipallocator.log
+JAVADIR=/usr/share/java
+LIBEXECDIR=/usr/libexec
+LOCKDIR=/var/lock
+MSCLASSPATH=
+MSCONF=/etc/cloudstack/management
+MSENVIRON=/usr/share/cloudstack-management
+MSLOG=/var/log/cloudstack/management/management-server.log
+MSLOGDIR=/var/log/cloudstack/management/
+MSMNTDIR=/var/cloudstack/mnt
+MSUSER=cloud
+PIDDIR=/var/run
+PLUGINJAVADIR=/usr/share/cloudstack-management/plugin
+PREMIUMJAVADIR=/usr/share/cloudstack-management/premium
+PYTHONDIR=/usr/lib/python2.6/site-packages/
+SERVERSYSCONFDIR=/etc/sysconfig
+SETUPDATADIR=/usr/share/cloudstack-management/setup
+SYSCONFDIR=/etc/sysconfig
+SYSTEMCLASSPATH=
+SYSTEMJARS=
+USAGECLASSPATH=
+USAGELOG=/var/log/cloudstack/usage/usage.log
+USAGESYSCONFDIR=/etc/sysconfig

--- a/packaging/fedora20/tomcat.sh
+++ b/packaging/fedora20/tomcat.sh
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+service tomcat start

--- a/packaging/fedora21/cloud-agent.rc
+++ b/packaging/fedora21/cloud-agent.rc
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# chkconfig: 35 99 10
+# description: Cloud Agent
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# WARNING: if this script is changed, then all other initscripts MUST BE changed to match it as well
+
+. /etc/rc.d/init.d/functions
+
+# set environment variables
+
+SHORTNAME=$(basename $0 | sed -e 's/^[SK][0-9][0-9]//')
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+LOGDIR=/var/log/cloudstack/agent
+LOGFILE=${LOGDIR}/agent.log
+PROGNAME="Cloud Agent"
+CLASS="com.cloud.agent.AgentShell"
+JSVC=`which jsvc 2>/dev/null`;
+
+# exit if we don't find jsvc
+if [ -z "$JSVC" ]; then
+    echo no jsvc found in path;
+    exit 1;
+fi
+
+unset OPTIONS
+[ -r /etc/sysconfig/"$SHORTNAME" ] && source /etc/sysconfig/"$SHORTNAME"
+
+# The first existing directory is used for JAVA_HOME (if JAVA_HOME is not defined in $DEFAULT)
+JDK_DIRS="/usr/lib/jvm/jre /usr/lib/jvm/java-7-openjdk /usr/lib/jvm/java-7-openjdk-i386 /usr/lib/jvm/java-7-openjdk-amd64 /usr/lib/jvm/java-6-openjdk /usr/lib/jvm/java-6-openjdk-i386 /usr/lib/jvm/java-6-openjdk-amd64 /usr/lib/jvm/java-6-sun"
+
+for jdir in $JDK_DIRS; do
+    if [ -r "$jdir/bin/java" -a -z "${JAVA_HOME}" ]; then
+        JAVA_HOME="$jdir"
+    fi
+done
+export JAVA_HOME
+
+ACP=`ls /usr/share/cloudstack-agent/lib/*.jar | tr '\n' ':' | sed s'/.$//'`
+PCP=`ls /usr/share/cloudstack-agent/plugins/*.jar 2>/dev/null | tr '\n' ':' | sed s'/.$//'`
+
+# We need to append the JSVC daemon JAR to the classpath
+# AgentShell implements the JSVC daemon methods
+export CLASSPATH="/usr/share/java/commons-daemon.jar:$ACP:$PCP:/etc/cloudstack/agent:/usr/share/cloudstack-common/scripts"
+
+start() {
+    echo -n $"Starting $PROGNAME: "
+    if hostname --fqdn >/dev/null 2>&1 ; then
+        $JSVC -Xms256m -Xmx2048m -cp "$CLASSPATH" -pidfile "$PIDFILE" \
+            -errfile $LOGDIR/cloudstack-agent.err -outfile $LOGDIR/cloudstack-agent.out $CLASS
+        RETVAL=$?
+        echo
+    else
+        failure
+        echo
+        echo The host name does not resolve properly to an IP address.  Cannot start "$PROGNAME". > /dev/stderr
+        RETVAL=9
+    fi
+    [ $RETVAL = 0 ] && touch ${LOCKFILE}
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping $PROGNAME: "
+    $JSVC -pidfile "$PIDFILE" -stop $CLASS
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && rm -f ${LOCKFILE} ${PIDFILE}
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status -p ${PIDFILE} $SHORTNAME
+        RETVAL=$?
+        ;;
+    restart)
+        stop
+        sleep 3
+        start
+        ;;
+    condrestart)
+        if status -p ${PIDFILE} $SHORTNAME >&/dev/null; then
+            stop
+            sleep 3
+            start
+        fi
+        ;;
+    *)
+    echo $"Usage: $SHORTNAME {start|stop|restart|condrestart|status|help}"
+    RETVAL=3
+esac
+
+exit $RETVAL

--- a/packaging/fedora21/cloud-ipallocator.rc
+++ b/packaging/fedora21/cloud-ipallocator.rc
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# chkconfig: 35 99 10
+# description: Cloud Agent
+
+# WARNING: if this script is changed, then all other initscripts MUST BE changed to match it as well
+
+. /etc/rc.d/init.d/functions
+
+# set environment variables
+
+SHORTNAME="$(basename $(readlink -f $0))"
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+LOGFILE=/var/log/cloudstack/ipallocator/ipallocator.log
+PROGNAME="External IPAllocator"
+
+unset OPTIONS
+[ -r /etc/sysconfig/"$SHORTNAME" ] && source /etc/sysconfig/"$SHORTNAME"
+DAEMONIZE=/usr/bin/cloud-daemonize
+PROG=/usr/bin/cloud-external-ipallocator.py
+OPTIONS=8083
+
+start() {
+        echo -n $"Starting $PROGNAME: "
+	if hostname --fqdn >/dev/null 2>&1 ; then
+		daemon --check=$SHORTNAME --pidfile=${PIDFILE} "$DAEMONIZE" \
+			-n "$SHORTNAME" -p "$PIDFILE" -l "$LOGFILE" "$PROG" $OPTIONS
+		RETVAL=$?
+		echo
+	else
+		failure
+		echo
+		echo The host name does not resolve properly to an IP address.  Cannot start "$PROGNAME". > /dev/stderr
+		RETVAL=9
+	fi
+	[ $RETVAL = 0 ] && touch ${LOCKFILE}
+	return $RETVAL
+}
+
+stop() {
+	echo -n $"Stopping $PROGNAME: "
+	killproc -p ${PIDFILE} $SHORTNAME # -d 10 $SHORTNAME
+	RETVAL=$?
+	echo
+	[ $RETVAL = 0 ] && rm -f ${LOCKFILE} ${PIDFILE}
+}
+
+
+# See how we were called.
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  status)
+        status -p ${PIDFILE} $SHORTNAME
+	RETVAL=$?
+	;;
+  restart)
+	stop
+	sleep 3
+	start
+	;;
+  condrestart)
+	if status -p ${PIDFILE} $SHORTNAME >&/dev/null; then
+		stop
+		sleep 3
+		start
+	fi
+	;;
+  *)
+	echo $"Usage: $SHORTNAME {start|stop|restart|condrestart|status|help}"
+	RETVAL=3
+esac
+
+exit $RETVAL
+

--- a/packaging/fedora21/cloud-management.rc
+++ b/packaging/fedora21/cloud-management.rc
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# cloudstack-management      This shell script takes care of starting and stopping Tomcat
+#
+# chkconfig: - 80 20
+#
+### BEGIN INIT INFO
+# Provides: tomcat6
+# Required-Start: $network $syslog
+# Required-Stop: $network $syslog
+# Default-Start:
+# Default-Stop:
+# Description: Release implementation for Servlet 2.5 and JSP 2.1
+# Short-Description: start and stop tomcat
+### END INIT INFO
+#
+# - originally written by Henri Gomez, Keith Irwin, and Nicolas Mailhot
+# - heavily rewritten by Deepak Bhole and Jason Corley
+#
+
+if [ -r /etc/rc.d/init.d/functions ]; then
+    . /etc/rc.d/init.d/functions
+fi
+if [ -r /lib/lsb/init-functions ]; then
+    . /lib/lsb/init-functions
+fi
+
+
+NAME="$(basename $(readlink -f $0))"
+export SERVICE_NAME="$NAME"
+stop() {
+	SHUTDOWN_WAIT="30"
+	count="0"
+	if [ -f /var/run/${NAME}.pid ]; then
+		pid=`cat /var/run/${NAME}.pid`
+		kill $pid &>/dev/null
+		until [ "$(ps --pid $pid | grep -c $pid)" -eq "0" ] || \
+			[ "$count" -gt "$SHUTDOWN_WAIT" ]
+		do
+			sleep 1
+			let count="${count}+1"
+		done
+		if [ "$(ps --pid $pid | grep -c $pid)" -eq "0" ]; then
+			log_success_msg "Stopping ${NAME}:"
+			rm -f /var/run/${NAME}.pid
+			rm -f /var/lock/subsys/${NAME}
+		else
+			log_failure_msg "Stopping ${NAME}:"
+		fi
+	else
+		echo "Cannot find PID file of ${NAME}"
+		log_failure_msg "Stopping ${NAME}:"
+	fi
+}
+
+set_ulimit() {
+    fd_limit=`ulimit -n`
+    if [ "$fd_limit" != "4096" ]; then
+        user=`whoami`
+        if [ $user == "root" ]; then
+            ulimit -n 4096
+        fi
+    fi
+}
+
+handle_pid_file() {
+     if [ "$1" -ne 0 ] && [ "$1" -ne 3 ]; then
+        echo "The pid file locates at /var/run/${NAME}.pid and lock file at /var/lock/subsys/${NAME}.
+        Starting ${NAME} will take care of them or you can manually clean up."
+    fi
+}
+
+start() {
+    readpath=$(readlink -f $0)
+    source `dirname $readpath`/tomcat.sh
+}
+
+# See how we were called.
+case "$1" in
+    status)
+		status ${NAME}
+		RETVAL=$?
+        handle_pid_file $RETVAL
+		;;
+    stop)
+		stop
+		;;
+    restart)
+		stop
+		set start
+        set_ulimit
+	        start
+		;;
+	*)
+        set_ulimit
+                start
+esac
+
+exit $RETVAL

--- a/packaging/fedora21/cloud-management.sysconfig
+++ b/packaging/fedora21/cloud-management.sysconfig
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This file is loaded in /etc/init.d/vmopsmanagement
+# ATM we only do two things here:
+
+dummy=1 ; export TOMCAT_CFG=/etc/cloudstack/management/tomcat6.conf ; . /etc/cloudstack/management/tomcat6.conf
+#--------------------------
+

--- a/packaging/fedora21/cloud-usage.rc
+++ b/packaging/fedora21/cloud-usage.rc
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+### BEGIN INIT INFO
+# Provides:          cloudstack-usage
+# Required-Start:    $network $local_fs
+# Required-Stop:     $network $local_fs
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Start/stop Apache CloudStack Usage Monitor
+# Description: This scripts Starts/Stops the Apache CloudStack Usage Monitor
+##  The CloudStack Usage Monitor is a part of the Apache CloudStack project and is used
+##  for storing usage statistics from instances.
+## JSVC (Java daemonizing) is used for starting and stopping the usage monitor.
+### END INIT INFO
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+. /etc/rc.d/init.d/functions
+
+SHORTNAME="cloudstack-usage"
+PIDFILE=/var/run/"$SHORTNAME".pid
+LOCKFILE=/var/lock/subsys/"$SHORTNAME"
+LOGDIR=/var/log/cloudstack/usage
+LOGFILE=${LOGDIR}/usage.log
+PROGNAME="CloudStack Usage Monitor"
+CLASS="com.cloud.usage.UsageServer"
+PROG="jsvc"
+DAEMON="/usr/bin/jsvc"
+USER=cloud
+
+unset OPTIONS
+[ -r /etc/sysconfig/default/"$SHORTNAME" ] && source /etc/sysconfig/default/"$SHORTNAME"
+
+setJavaHome() {
+  # use $JAVA_HOME if defined
+  if [ -n "$JAVA_HOME" ] ; then
+    return
+  fi
+
+  # try java first
+  java=$(which java 2>/dev/null || :)
+
+  # try javac if java is not found
+  if [ -z "$java" ] ; then
+    java=$(which javac 2>/dev/null || :)
+  fi
+
+  if [ -n "$java" ] ; then
+    JAVA_HOME=$(dirname $(dirname $(readlink -e $java)))
+    export JAVA_HOME
+    return
+  fi
+
+  # didnt find java home. exiting with error
+  exit 1
+}
+
+setJavaHome
+
+SCP=""
+DCP=""
+UCP=`ls /usr/share/cloudstack-usage/cloud-usage-*.jar`":"`ls /usr/share/cloudstack-usage/lib/*.jar | tr '\n' ':'`
+JCP="/usr/share/java/commons-daemon.jar":"/usr/share/java/mysql-connector-java.jar"
+
+# We need to append the JSVC daemon  and mysql-connector JAR to the classpath
+# AgentShell implements the JSVC daemon methods
+export CLASSPATH="$SCP:$DCP:$UCP:$JCP:/etc/cloudstack/usage"
+
+start() {
+    if [ -s "$PIDFILE" ] && kill -0 $(cat "$PIDFILE") >/dev/null 2>&1; then
+        echo "$PROGNAME apparently already running"
+        exit 0
+    fi
+
+    if hostname --fqdn >/dev/null 2>&1 ; then
+        true
+    else
+        echo "The host name does not resolve properly to an IP address. Cannot start $PROGNAME"
+        exit 1
+    fi
+
+    echo -n "Starting $PROGNAME" "$SHORTNAME"
+
+    if daemon --pidfile $PIDFILE $DAEMON -home "$JAVA_HOME" -cp "$CLASSPATH" -pidfile "$PIDFILE" -user "$USER" \
+      -errfile $LOGDIR/cloudstack-usage.err -outfile $LOGDIR/cloudstack-usage.out -Dpid=$$ $CLASS
+        RETVAL=$?
+    then
+        rc=0
+        sleep 1
+        if ! kill -0 $(cat "$PIDFILE") >/dev/null 2>&1; then
+            failure
+            rc=1
+        fi
+    else
+        rc=1
+    fi
+
+    if [ $rc -eq 0 ]; then
+        success
+    else
+        failure
+        rm -f "$PIDFILE"
+    fi
+    echo
+}
+
+stop() {
+    echo -n "Stopping $PROGNAME" "$SHORTNAME"
+    killproc -p $PIDFILE $DAEMON
+    if [ "$?" -eq 0 ]; then
+        success
+    else
+        failure
+    fi
+    rm -f "$PIDFILE"
+    echo
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status -p $PIDFILE $SHORTNAME
+        RETVAL=$?
+        ;;
+    restart | force-reload)
+        stop
+        sleep 3
+        start
+        ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|force-reload|status}"
+    RETVAL=3
+esac
+
+exit $RETVAL
+

--- a/packaging/fedora21/cloud.spec
+++ b/packaging/fedora21/cloud.spec
@@ -1,0 +1,648 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+%define __os_install_post %{nil}
+%global debug_package %{nil}
+
+# DISABLE the post-percentinstall java repacking and line number stripping
+# we need to find a way to just disable the java repacking and line number stripping, but not the autodeps
+
+Name:      cloudstack
+Summary:   CloudStack IaaS Platform
+#http://fedoraproject.org/wiki/PackageNamingGuidelines#Pre-Release_packages
+%if "%{?_prerelease}" != ""
+%define _maventag %{_ver}-SNAPSHOT
+Release:   %{_rel}%{dist}
+%else
+%define _maventag %{_ver}
+Release:   %{_rel}%{dist}
+%endif
+
+%{!?python_sitearch: %define python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
+
+Version:   %{_ver}
+License:   ASL 2.0
+Vendor:    Apache CloudStack <dev@cloudstack.apache.org>
+Packager:  Apache CloudStack <dev@cloudstack.apache.org>
+Group:     System Environment/Libraries
+# FIXME do groups for every single one of the subpackages
+Source0:   %{name}-%{_maventag}.tgz
+BuildRoot: %{_tmppath}/%{name}-%{_maventag}-%{release}-build
+
+BuildRequires: java-1.8.0-openjdk-devel
+BuildRequires: tomcat
+BuildRequires: ws-commons-util
+BuildRequires: jpackage-utils
+BuildRequires: gcc
+BuildRequires: glibc-devel
+BuildRequires: /usr/bin/mkisofs
+BuildRequires: MySQL-python
+#BuildRequires: maven => 3.0.0
+
+%description
+CloudStack is a highly-scalable elastic, open source,
+intelligent IaaS cloud implementation.
+
+%package management
+Summary:   CloudStack management server UI
+Requires: tomcat
+Requires: java-1.8.0-openjdk
+Requires: python
+Requires: bash
+Requires: bzip2
+Requires: gzip
+Requires: unzip
+Requires: /sbin/mount.nfs
+Requires: openssh-clients
+Requires: nfs-utils
+Requires: wget
+Requires: mysql
+Requires: mysql-connector-java
+Requires: ws-commons-util
+Requires: jpackage-utils
+Requires: sudo
+Requires: /sbin/service
+Requires: /sbin/chkconfig
+Requires: /usr/bin/ssh-keygen
+Requires: mkisofs
+Requires: MySQL-python
+Requires: python-paramiko
+Requires: ipmitool
+Requires: %{name}-common = %{_ver}
+Obsoletes: cloud-client < 4.1.0
+Obsoletes: cloud-client-ui < 4.1.0
+Obsoletes: cloud-server < 4.1.0
+Obsoletes: cloud-test < 4.1.0
+Provides:  cloud-client
+Group:     System Environment/Libraries
+%description management
+The CloudStack management server is the central point of coordination,
+management, and intelligence in CloudStack.  
+
+%package common
+Summary: Apache CloudStack common files and scripts
+Requires: python
+Obsoletes: cloud-test < 4.1.0 
+Obsoletes: cloud-scripts < 4.1.0
+Obsoletes: cloud-utils < 4.1.0
+Obsoletes: cloud-core < 4.1.0
+Obsoletes: cloud-deps < 4.1.0
+Obsoletes: cloud-python < 4.1.0
+Obsoletes: cloud-setup < 4.1.0
+Obsoletes: cloud-cli < 4.1.0
+Obsoletes: cloud-daemonize < 4.1.0
+Group:   System Environment/Libraries
+%description common
+The Apache CloudStack files shared between agent and management server
+
+%package agent
+Summary: CloudStack Agent for KVM hypervisors
+Requires: openssh-clients
+Requires: java-1.8.0-openjdk
+Requires: %{name}-common = %{_ver}
+Requires: libvirt
+Requires: bridge-utils
+Requires: ebtables
+Requires: iptables
+Requires: ethtool
+Requires: vconfig
+Requires: ipset
+Requires: jsvc
+Requires: jakarta-commons-daemon
+Requires: jakarta-commons-daemon-jsvc
+Requires: perl
+Requires: libvirt-python
+Requires: qemu-img
+Requires: qemu-kvm
+Requires: libcgroup-tools
+Requires: net-tools
+Provides: cloud-agent
+Obsoletes: cloud-agent < 4.1.0
+Obsoletes: cloud-agent-libs < 4.1.0
+Obsoletes: cloud-test < 4.1.0
+Group: System Environment/Libraries
+%description agent
+The CloudStack agent for KVM hypervisors
+
+%package baremetal-agent
+Summary: CloudStack baremetal agent
+Requires: tftp-server
+Requires: xinetd
+Requires: syslinux
+Requires: chkconfig
+Requires: dhcp
+Requires: httpd
+Group:     System Environment/Libraries
+%description baremetal-agent
+The CloudStack baremetal agent
+
+%package usage
+Summary: CloudStack Usage calculation server
+Requires: java-1.8.0-openjdk
+Requires: jsvc
+Requires: jakarta-commons-daemon
+Requires: jakarta-commons-daemon-jsvc
+Group: System Environment/Libraries
+Obsoletes: cloud-usage < 4.1.0
+Provides: cloud-usage 
+%description usage
+The CloudStack usage calculation service
+
+%package cli
+Summary: Apache CloudStack CLI
+Provides: python-cloudmonkey
+Provides: python-marvin
+Group: System Environment/Libraries
+%description cli
+Apache CloudStack command line interface
+
+%if "%{_ossnoss}" == "noredist"
+%package mysql-ha
+Summary: Apache CloudStack Balancing Strategy for MySQL
+Requires: mysql-connector-java
+Requires: tomcat
+Group: System Environmnet/Libraries
+%description mysql-ha
+Apache CloudStack Balancing Strategy for MySQL
+
+%endif
+
+%prep
+echo Doing CloudStack build
+
+%setup -q -n %{name}-%{_maventag}
+
+%build
+
+cp packaging/centos63/replace.properties build/replace.properties
+echo VERSION=%{_maventag} >> build/replace.properties
+echo PACKAGE=%{name} >> build/replace.properties
+touch build/gitrev.txt
+echo $(git rev-parse HEAD) > build/gitrev.txt
+
+if [ "%{_ossnoss}" == "NOREDIST" -o "%{_ossnoss}" == "noredist" ] ; then
+   echo "Executing mvn packaging with non-redistributable libraries"
+   if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then 
+      echo "Executing mvn noredist packaging with simulator ..."
+      mvn -Psystemvm -Dnoredist -Dsimulator clean package
+   else
+      echo "Executing mvn noredist packaging without simulator..."
+      mvn -Psystemvm -Dnoredist clean package
+   fi
+else
+   if [ "%{_sim}" == "SIMULATOR" -o "%{_sim}" == "simulator" ] ; then 
+      echo "Executing mvn default packaging simulator ..."
+      mvn -Psystemvm -Dsimulator clean package
+   else
+      echo "Executing mvn default packaging without simulator ..."
+      mvn -Psystemvm clean package
+   fi
+fi 
+
+%install
+[ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
+# Common directories
+mkdir -p ${RPM_BUILD_ROOT}%{_bindir}
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/ipallocator
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
+mkdir -p ${RPM_BUILD_ROOT}%{_initrddir}
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/sysconfig
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/profile.d
+
+# Common
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms
+mkdir -p ${RPM_BUILD_ROOT}%{python_sitearch}/
+mkdir -p ${RPM_BUILD_ROOT}%/usr/bin
+cp -r scripts/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+install -D systemvm/dist/systemvm.iso ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms/systemvm.iso
+install -D systemvm/dist/systemvm.zip ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/vms/systemvm.zip
+install python/lib/cloud_utils.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloud_utils.py
+cp -r python/lib/cloudutils ${RPM_BUILD_ROOT}%{python_sitearch}/
+python -m py_compile ${RPM_BUILD_ROOT}%{python_sitearch}/cloud_utils.py
+python -m compileall ${RPM_BUILD_ROOT}%{python_sitearch}/cloudutils
+cp build/gitrev.txt ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts
+cp packaging/centos63/cloudstack-sccs ${RPM_BUILD_ROOT}/usr/bin
+ 
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts/network/cisco
+cp -r plugins/network-elements/cisco-vnmc/scripts/network/cisco/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/scripts/network/cisco
+
+# Management
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management
+
+# Specific for tomcat
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+ln -sf /usr/share/tomcat/bin ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/bin
+ln -sf /etc/%{name}/management ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/conf
+ln -sf /usr/share/tomcat/lib ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/lib
+ln -sf /var/log/%{name}/management ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/logs
+ln -sf /var/cache/%{name}/management/temp ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/temp
+ln -sf /var/cache/%{name}/management/work ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/work
+
+/bin/touch ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management/catalina.out
+
+install -D client/target/utilities/bin/cloud-migrate-databases ${RPM_BUILD_ROOT}%{_bindir}/%{name}-migrate-databases
+install -D client/target/utilities/bin/cloud-set-guest-password ${RPM_BUILD_ROOT}%{_bindir}/%{name}-set-guest-password
+install -D client/target/utilities/bin/cloud-set-guest-sshkey ${RPM_BUILD_ROOT}%{_bindir}/%{name}-set-guest-sshkey
+install -D client/target/utilities/bin/cloud-setup-databases ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-databases
+install -D client/target/utilities/bin/cloud-setup-encryption ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-encryption
+install -D client/target/utilities/bin/cloud-setup-management ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-management
+install -D client/target/utilities/bin/cloud-setup-baremetal ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-baremetal
+install -D client/target/utilities/bin/cloud-sysvmadm ${RPM_BUILD_ROOT}%{_bindir}/%{name}-sysvmadm
+install -D client/target/utilities/bin/cloud-update-xenserver-licenses ${RPM_BUILD_ROOT}%{_bindir}/%{name}-update-xenserver-licenses
+
+cp -r client/target/utilities/scripts/db/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/setup
+cp -r client/target/cloud-client-ui-%{_maventag}/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client
+
+# Don't package the scripts in the management webapp
+rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/scripts
+rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/vms
+
+for name in db.properties log4j-cloud.xml tomcat6-nonssl.conf tomcat6-ssl.conf server-ssl.xml server-nonssl.xml \
+            catalina.policy catalina.properties classpath.conf tomcat-users.xml web.xml environment.properties java.security.ciphers ; do
+  mv ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/$name \
+    ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/$name
+done
+
+ln -s %{_sysconfdir}/%{name}/management/log4j-cloud.xml \
+    ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/log4j-cloud.xml
+
+mv ${RPM_BUILD_ROOT}%{_datadir}/%{name}-management/webapps/client/WEB-INF/classes/context.xml \
+    ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+
+install python/bindir/cloud-external-ipallocator.py ${RPM_BUILD_ROOT}%{_bindir}/%{name}-external-ipallocator.py
+install -D client/target/pythonlibs/jasypt-1.9.2.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/lib/jasypt-1.9.2.jar
+
+install -D packaging/centos63/cloud-ipallocator.rc ${RPM_BUILD_ROOT}%{_initrddir}/%{name}-ipallocator
+install -D packaging/centos63/cloud-management.rc ${RPM_BUILD_ROOT}%{_initrddir}/%{name}-management
+install -D packaging/centos63/cloud-management.sysconfig ${RPM_BUILD_ROOT}%{_sysconfdir}/sysconfig/%{name}-management
+install -D packaging/centos63/tomcat.sh ${RPM_BUILD_ROOT}%{_initrddir}/tomcat.sh
+
+chmod 440 ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost
+chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+
+# KVM Agent
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/plugins
+install -D packaging/centos63/cloud-agent.rc ${RPM_BUILD_ROOT}%{_sysconfdir}/init.d/%{name}-agent
+install -D agent/target/transformed/agent.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/agent.properties
+install -D agent/target/transformed/environment.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/environment.properties
+install -D agent/target/transformed/log4j-cloud.xml ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/agent/log4j-cloud.xml
+install -D agent/target/transformed/cloud-setup-agent ${RPM_BUILD_ROOT}%{_bindir}/%{name}-setup-agent
+install -D agent/target/transformed/cloudstack-agent-upgrade ${RPM_BUILD_ROOT}%{_bindir}/%{name}-agent-upgrade
+install -D agent/target/transformed/libvirtqemuhook ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib/libvirtqemuhook
+install -D agent/target/transformed/cloud-ssh ${RPM_BUILD_ROOT}%{_bindir}/%{name}-ssh
+install -D agent/target/transformed/cloudstack-agent-profile.sh ${RPM_BUILD_ROOT}%{_sysconfdir}/profile.d/%{name}-agent-profile.sh
+install -D agent/target/transformed/cloudstack-agent.logrotate ${RPM_BUILD_ROOT}%{_sysconfdir}/logrotate.d/%{name}-agent
+install -D plugins/hypervisors/kvm/target/cloud-plugin-hypervisor-kvm-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%name-agent/lib/cloud-plugin-hypervisor-kvm-%{_maventag}.jar
+cp plugins/hypervisors/kvm/target/dependencies/*  ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib
+
+# Usage server
+mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage
+mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib
+install -D usage/target/cloud-usage-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/cloud-usage-%{_maventag}.jar
+install -D usage/target/transformed/db.properties ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage/db.properties
+install -D usage/target/transformed/log4j-cloud_usage.xml ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/usage/log4j-cloud.xml
+cp usage/target/dependencies/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib/
+install -D packaging/centos63/cloud-usage.rc ${RPM_BUILD_ROOT}/%{_sysconfdir}/init.d/%{name}-usage
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/usage/
+
+# CLI
+cp -r cloud-cli/cloudtool ${RPM_BUILD_ROOT}%{python_sitearch}/
+install cloud-cli/cloudapis/cloud.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloudapis.py
+
+# MYSQL HA
+if [ "x%{_ossnoss}" == "xnoredist" ] ; then
+  mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-mysql-ha/lib
+  cp -r plugins/database/mysql-ha/target/cloud-plugin-database-mysqlha-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-mysql-ha/lib
+fi
+
+#License files from whisker
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-management-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-management-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-common-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-common-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-agent-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-agent-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
+install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-cli-%{version}/NOTICE
+install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-cli-%{version}/LICENSE
+if [ "x%{_ossnoss}" == "xnoredist" ] ; then
+  install -D tools/whisker/LICENSE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-mysql-ha-%{version}/LICENSE
+  install -D tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-mysql-ha-%{version}/NOTICE
+fi
+
+%clean
+[ ${RPM_BUILD_ROOT} != "/" ] && rm -rf ${RPM_BUILD_ROOT}
+
+%preun management
+/sbin/service cloudstack-management stop || true
+if [ "$1" == "0" ] ; then
+    /sbin/chkconfig --del cloudstack-management  > /dev/null 2>&1 || true
+    /sbin/service cloudstack-management stop > /dev/null 2>&1 || true
+fi
+
+%pre management
+id cloud > /dev/null 2>&1 || /usr/sbin/useradd -M -c "CloudStack unprivileged user" \
+     -r -s /bin/sh -d %{_localstatedir}/cloudstack/management cloud|| true
+
+# set max file descriptors for cloud user to 4096
+sed -i /"cloud hard nofile"/d /etc/security/limits.conf
+sed -i /"cloud soft nofile"/d /etc/security/limits.conf
+echo "cloud hard nofile 4096" >> /etc/security/limits.conf
+echo "cloud soft nofile 4096" >> /etc/security/limits.conf
+rm -rf %{_localstatedir}/cache/cloud
+rm -rf %{_localstatedir}/cache/cloudstack
+# user harcoded here, also hardcoded on wscript
+
+# save old configs if they exist (for upgrade). Otherwise we may lose them
+# when the old packages are erased. There are a lot of properties files here.
+if [ -d "%{_sysconfdir}/cloud" ] ; then
+    mv %{_sysconfdir}/cloud %{_sysconfdir}/cloud.rpmsave
+fi
+
+%post management
+if [ "$1" == "1" ] ; then
+    /sbin/chkconfig --add cloudstack-management > /dev/null 2>&1 || true
+    /sbin/chkconfig --level 345 cloudstack-management on > /dev/null 2>&1 || true
+fi
+
+if [ ! -f %{_datadir}/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util ] ; then
+    echo Please download vhd-util from http://download.cloud.com.s3.amazonaws.com/tools/vhd-util and put it in 
+    echo %{_datadir}/cloudstack-common/scripts/vm/hypervisor/xenserver/
+fi
+
+# change cloud user's home to 4.1+ version if needed. Would do this via 'usermod', but it
+# requires that cloud user not be in use, so RPM could not be installed while management is running
+if getent passwd cloud | grep -q /var/lib/cloud; then 
+    sed -i 's/\/var\/lib\/cloud\/management/\/var\/cloudstack\/management/g' /etc/passwd
+fi
+
+# if saved configs from upgrade exist, copy them over
+if [ -f "%{_sysconfdir}/cloud.rpmsave/management/db.properties" ]; then
+    mv %{_sysconfdir}/%{name}/management/db.properties %{_sysconfdir}/%{name}/management/db.properties.rpmnew
+    cp -p %{_sysconfdir}/cloud.rpmsave/management/db.properties %{_sysconfdir}/%{name}/management
+    if [ -f "%{_sysconfdir}/cloud.rpmsave/management/key" ]; then    
+        cp -p %{_sysconfdir}/cloud.rpmsave/management/key %{_sysconfdir}/%{name}/management
+    fi
+    # make sure we only do this on the first install of this RPM, don't want to overwrite on a reinstall
+    mv %{_sysconfdir}/cloud.rpmsave/management/db.properties %{_sysconfdir}/cloud.rpmsave/management/db.properties.rpmsave
+fi
+
+# Choose server.xml and tomcat.conf links based on old config, if exists
+serverxml=%{_sysconfdir}/%{name}/management/server.xml
+oldserverxml=%{_sysconfdir}/cloud.rpmsave/management/server.xml
+if [ -f $oldserverxml ] || [ -L $oldserverxml ]; then
+    if stat -c %N $oldserverxml| grep -q server-ssl ; then
+        if [ -f $serverxml ] || [ -L $serverxml ]; then rm -f $serverxml; fi
+        ln -s %{_sysconfdir}/%{name}/management/server-ssl.xml $serverxml
+        echo Please verify the server.xml in saved folder, and make the required changes manually , saved folder available at $oldserverxml
+    else
+        if [ -f $serverxml ] || [ -L $serverxml ]; then rm -f $serverxml; fi
+        ln -s %{_sysconfdir}/%{name}/management/server-nonssl.xml $serverxml
+        echo Please verify the server.xml in saved folder, and make the required changes manually , saved folder available at $oldserverxml
+
+    fi
+else
+    echo "Unable to determine ssl settings for server.xml, please run cloudstack-setup-management manually"
+fi
+
+
+tomcatconf=%{_sysconfdir}/%{name}/management/tomcat6.conf
+oldtomcatconf=%{_sysconfdir}/cloud.rpmsave/management/tomcat6.conf
+if [ -f $oldtomcatconf ] || [ -L $oldtomcatconf ] ; then
+    if stat -c %N $oldtomcatconf| grep -q tomcat6-ssl ; then
+        if [ -f $tomcatconf ] || [ -L $tomcatconf ]; then rm -f $tomcatconf; fi
+        ln -s %{_sysconfdir}/%{name}/management/tomcat6-ssl.conf $tomcatconf
+        echo Please verify the tomcat6.conf in saved folder, and make the required changes manually , saved folder available at $oldtomcatconf
+    else
+        if [ -f $tomcatconf ] || [ -L $tomcatconf ]; then rm -f $tomcatconf; fi
+        ln -s %{_sysconfdir}/%{name}/management/tomcat6-nonssl.conf $tomcatconf
+        echo Please verify the tomcat6.conf in saved folder, and make the required changes manually , saved folder available at $oldtomcatconf
+    fi
+else
+    echo "Unable to determine ssl settings for tomcat.conf, please run cloudstack-setup-management manually"
+fi
+
+if [ -f "%{_sysconfdir}/cloud.rpmsave/management/cloud.keystore" ]; then
+    cp -p %{_sysconfdir}/cloud.rpmsave/management/cloud.keystore %{_sysconfdir}/%{name}/management/cloudmanagementserver.keystore
+    # make sure we only do this on the first install of this RPM, don't want to overwrite on a reinstall
+    mv %{_sysconfdir}/cloud.rpmsave/management/cloud.keystore %{_sysconfdir}/cloud.rpmsave/management/cloud.keystore.rpmsave
+fi
+
+%preun agent
+/sbin/service cloudstack-agent stop || true
+if [ "$1" == "0" ] ; then
+    /sbin/chkconfig --del cloudstack-agent > /dev/null 2>&1 || true
+    /sbin/service cloudstack-agent stop > /dev/null 2>&1 || true
+fi
+
+%pre agent
+
+# save old configs if they exist (for upgrade). Otherwise we may lose them
+# when the old packages are erased. There are a lot of properties files here.
+if [ -d "%{_sysconfdir}/cloud" ] ; then
+    mv %{_sysconfdir}/cloud %{_sysconfdir}/cloud.rpmsave
+fi
+
+%post agent
+if [ "$1" == "1" ] ; then
+    echo "Running %{_bindir}/%{name}-agent-upgrade to update bridge name for upgrade from CloudStack 4.0.x (and before) to CloudStack 4.1 (and later)"
+    %{_bindir}/%{name}-agent-upgrade
+    if [ ! -d %{_sysconfdir}/libvirt/hooks ] ; then
+        mkdir %{_sysconfdir}/libvirt/hooks
+    fi
+    cp -a ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib/libvirtqemuhook %{_sysconfdir}/libvirt/hooks/qemu
+    /sbin/service libvirtd restart
+    /sbin/chkconfig --add cloudstack-agent > /dev/null 2>&1 || true
+    /sbin/chkconfig --level 345 cloudstack-agent on > /dev/null 2>&1 || true
+fi
+
+# if saved configs from upgrade exist, copy them over
+if [ -f "%{_sysconfdir}/cloud.rpmsave/agent/agent.properties" ]; then
+    mv %{_sysconfdir}/%{name}/agent/agent.properties  %{_sysconfdir}/%{name}/agent/agent.properties.rpmnew
+    cp -p %{_sysconfdir}/cloud.rpmsave/agent/agent.properties %{_sysconfdir}/%{name}/agent
+    # make sure we only do this on the first install of this RPM, don't want to overwrite on a reinstall
+    mv %{_sysconfdir}/cloud.rpmsave/agent/agent.properties %{_sysconfdir}/cloud.rpmsave/agent/agent.properties.rpmsave
+fi
+
+%preun usage
+/sbin/service cloudstack-usage stop || true
+if [ "$1" == "0" ] ; then
+    /sbin/chkconfig --del cloudstack-usage > /dev/null 2>&1 || true
+    /sbin/service cloudstack-usage stop > /dev/null 2>&1 || true
+fi
+
+%post usage
+if [ -f "%{_sysconfdir}/%{name}/management/db.properties" ]; then
+    echo Replacing db.properties with management server db.properties
+    rm -f %{_sysconfdir}/%{name}/usage/db.properties
+    ln -s %{_sysconfdir}/%{name}/management/db.properties %{_sysconfdir}/%{name}/usage/db.properties
+    /sbin/chkconfig --add cloudstack-usage > /dev/null 2>&1 || true
+    /sbin/chkconfig --level 345 cloudstack-usage on > /dev/null 2>&1 || true
+fi
+
+if [ -f "%{_sysconfdir}/%{name}/management/key" ]; then
+    echo Replacing key with management server key
+    rm -f %{_sysconfdir}/%{name}/usage/key
+    ln -s %{_sysconfdir}/%{name}/management/key %{_sysconfdir}/%{name}/usage/key
+fi
+
+#No default permission as the permission setup is complex
+%files management
+%defattr(-,root,root,-)
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina/localhost
+%dir %attr(0770,root,cloud) %{_sysconfdir}/%{name}/management/Catalina/localhost/client
+%dir %{_datadir}/%{name}-management
+%dir %attr(0770,root,cloud) %{_localstatedir}/%{name}/mnt
+%dir %attr(0770,cloud,cloud) %{_localstatedir}/%{name}/management
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/work
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/temp
+%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/management
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}-management
+%config(noreplace) %attr(0640,root,cloud) %{_sysconfdir}/%{name}/management/db.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/log4j-cloud.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/tomcat6-nonssl.conf
+%config(noreplace) %{_sysconfdir}/%{name}/management/tomcat6-ssl.conf
+%config(noreplace) %{_sysconfdir}/%{name}/management/Catalina/localhost/client/context.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/catalina.policy
+%config(noreplace) %{_sysconfdir}/%{name}/management/catalina.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/classpath.conf
+%config(noreplace) %{_sysconfdir}/%{name}/management/server-nonssl.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/server-ssl.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/tomcat-users.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/web.xml
+%config(noreplace) %{_sysconfdir}/%{name}/management/environment.properties
+%config(noreplace) %{_sysconfdir}/%{name}/management/java.security.ciphers
+%config(noreplace) %{_sysconfdir}/%{name}/management/commons-logging.properties
+%attr(0755,root,root) %{_initrddir}/%{name}-management
+%attr(0755,root,root) %{_initrddir}/tomcat.sh
+
+%attr(0755,root,root) %{_bindir}/%{name}-setup-management
+%attr(0755,root,root) %{_bindir}/%{name}-update-xenserver-licenses
+%{_datadir}/%{name}-management/webapps
+%{_datadir}/%{name}-management/bin
+%{_datadir}/%{name}-management/conf
+%{_datadir}/%{name}-management/lib
+%{_datadir}/%{name}-management/logs
+%{_datadir}/%{name}-management/temp
+%{_datadir}/%{name}-management/work
+%attr(0755,root,root) %{_bindir}/%{name}-setup-databases
+%attr(0755,root,root) %{_bindir}/%{name}-migrate-databases
+%attr(0755,root,root) %{_bindir}/%{name}-set-guest-password
+%attr(0755,root,root) %{_bindir}/%{name}-set-guest-sshkey
+%attr(0755,root,root) %{_bindir}/%{name}-sysvmadm
+%attr(0755,root,root) %{_bindir}/%{name}-setup-encryption
+%{_datadir}/%{name}-management/setup/*.sql
+%{_datadir}/%{name}-management/setup/db/*.sql
+%{_datadir}/%{name}-management/setup/*.sh
+%{_datadir}/%{name}-management/setup/server-setup.xml
+%attr(0755,root,root) %{_bindir}/%{name}-external-ipallocator.py
+%attr(0755,root,root) %{_initrddir}/%{name}-ipallocator
+%dir %attr(0770,root,root) %{_localstatedir}/log/%{name}/ipallocator
+%{_defaultdocdir}/%{name}-management-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-management-%{version}/NOTICE
+%attr(0644,cloud,cloud) %{_localstatedir}/log/%{name}/management/catalina.out
+
+%files agent
+%attr(0755,root,root) %{_bindir}/%{name}-setup-agent
+%attr(0755,root,root) %{_bindir}/%{name}-agent-upgrade
+%attr(0755,root,root) %{_bindir}/%{name}-ssh
+%attr(0755,root,root) %{_sysconfdir}/init.d/%{name}-agent
+%attr(0644,root,root) %{_sysconfdir}/profile.d/%{name}-agent-profile.sh
+%attr(0644,root,root) %{_sysconfdir}/logrotate.d/%{name}-agent
+%attr(0755,root,root) %{_datadir}/%{name}-common/scripts/network/cisco
+%config(noreplace) %{_sysconfdir}/%{name}/agent
+%dir %{_localstatedir}/log/%{name}/agent
+%attr(0644,root,root) %{_datadir}/%{name}-agent/lib/*.jar
+%attr(0755,root,root) %{_datadir}/%{name}-agent/lib/libvirtqemuhook
+%dir %{_datadir}/%{name}-agent/plugins
+%{_defaultdocdir}/%{name}-agent-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-agent-%{version}/NOTICE
+
+%files common
+%dir %attr(0755,root,root) %{python_sitearch}/cloudutils
+%dir %attr(0755,root,root) %{_datadir}/%{name}-common/vms
+%attr(0755,root,root) %{_datadir}/%{name}-common/scripts
+%attr(0755,root,root) /usr/bin/cloudstack-sccs
+%attr(0644, root, root) %{_datadir}/%{name}-common/vms/systemvm.iso
+%attr(0644, root, root) %{_datadir}/%{name}-common/vms/systemvm.zip
+%attr(0644,root,root) %{python_sitearch}/cloud_utils.py
+%attr(0644,root,root) %{python_sitearch}/cloud_utils.pyc
+%attr(0644,root,root) %{python_sitearch}/cloudutils/*
+%attr(0644, root, root) %{_datadir}/%{name}-common/lib/jasypt-1.9.2.jar
+%{_defaultdocdir}/%{name}-common-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-common-%{version}/NOTICE
+
+%files usage
+%attr(0755,root,root) %{_sysconfdir}/init.d/%{name}-usage
+%attr(0644,root,root) %{_datadir}/%{name}-usage/*.jar
+%attr(0644,root,root) %{_datadir}/%{name}-usage/lib/*.jar
+%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/usage
+%attr(0644,root,root) %{_sysconfdir}/%{name}/usage/db.properties
+%attr(0644,root,root) %{_sysconfdir}/%{name}/usage/log4j-cloud.xml
+%{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+
+%files cli
+%attr(0644,root,root) %{python_sitearch}/cloudapis.py
+%attr(0644,root,root) %{python_sitearch}/cloudtool/__init__.py
+%attr(0644,root,root) %{python_sitearch}/cloudtool/utils.py
+%{_defaultdocdir}/%{name}-cli-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-cli-%{version}/NOTICE
+
+%if "%{_ossnoss}" == "noredist"
+%files mysql-ha
+%defattr(0644,cloud,cloud,0755)
+%attr(0644,root,root) %{_datadir}/%{name}-mysql-ha/lib/*
+%{_defaultdocdir}/%{name}-mysql-ha-%{version}/LICENSE
+%{_defaultdocdir}/%{name}-mysql-ha-%{version}/NOTICE
+%endif
+
+%files baremetal-agent
+%attr(0755,root,root) %{_bindir}/cloudstack-setup-baremetal
+
+%changelog
+* Thu Apr 30 2015 Rohit Yadav <bhaisaab@apache.org> 4.6.0
+- Remove awsapi package
+
+* Fri Jul 04 2014 Hugo Trippaers <hugo@apache.org> 4.5.0
+- Add a package for the mysql ha module
+
+* Wed Oct 03 2012 Hugo Trippaers <hugo@apache.org> 4.1.0
+- new style spec file

--- a/packaging/fedora21/cloudstack-agent.te
+++ b/packaging/fedora21/cloudstack-agent.te
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module cloudstack-agent 1.0;
+
+require {
+	type nfs_t;
+	type system_conf_t;
+	type mount_t;
+	type qemu_t;
+	class file unlink;
+	class filesystem getattr;
+}
+
+#============= mount_t ==============
+allow mount_t system_conf_t:file unlink;
+
+#============= qemu_t ==============
+allow qemu_t nfs_t:filesystem getattr;

--- a/packaging/fedora21/cloudstack-sccs
+++ b/packaging/fedora21/cloudstack-sccs
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cat /usr/share/cloudstack-common/scripts/gitrev.txt

--- a/packaging/fedora21/replace.properties
+++ b/packaging/fedora21/replace.properties
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DBUSER=cloud
+DBPW=cloud
+DBROOTPW=
+MSLOG=vmops.log
+APISERVERLOG=api.log
+DBHOST=localhost
+COMPONENTS-SPEC=components-premium.xml
+REMOTEHOST=localhost
+AGENTCLASSPATH=
+AGENTLOG=/var/log/cloudstack/agent/agent.log
+AGENTLOGDIR=/var/log/cloudstack/agent/
+AGENTSYSCONFDIR=/etc/cloudstack/agent
+APISERVERLOG=/var/log/cloudstack/management/apilog.log
+BINDIR=/usr/bin
+COMMONLIBDIR=/usr/share/cloudstack-common
+CONFIGUREVARS=
+DEPSCLASSPATH=
+DOCDIR=
+IPALOCATORLOG=/var/log/cloudstack/management/ipallocator.log
+JAVADIR=/usr/share/java
+LIBEXECDIR=/usr/libexec
+LOCKDIR=/var/lock
+MSCLASSPATH=
+MSCONF=/etc/cloudstack/management
+MSENVIRON=/usr/share/cloudstack-management
+MSLOG=/var/log/cloudstack/management/management-server.log
+MSLOGDIR=/var/log/cloudstack/management/
+MSMNTDIR=/var/cloudstack/mnt
+MSUSER=cloud
+PIDDIR=/var/run
+PLUGINJAVADIR=/usr/share/cloudstack-management/plugin
+PREMIUMJAVADIR=/usr/share/cloudstack-management/premium
+PYTHONDIR=/usr/lib/python2.6/site-packages/
+SERVERSYSCONFDIR=/etc/sysconfig
+SETUPDATADIR=/usr/share/cloudstack-management/setup
+SYSCONFDIR=/etc/sysconfig
+SYSTEMCLASSPATH=
+SYSTEMJARS=
+USAGECLASSPATH=
+USAGELOG=/var/log/cloudstack/usage/usage.log
+USAGESYSCONFDIR=/etc/sysconfig

--- a/packaging/fedora21/tomcat.sh
+++ b/packaging/fedora21/tomcat.sh
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+service tomcat start

--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+function usage() {
+    echo ""
+    echo "usage: ./package.sh [-h|--help] -d|--distribution <name> [-r|--release <version>] [-p|--pack oss|OSS|noredist|NOREDIST] [-s|--simulator default|DEFAULT|simulator|SIMULATOR]"
+    echo ""
+    echo "The supported arguments are:"
+    echo "  To package with only redistributable libraries (default)"
+    echo "    -p|--pack oss|OSS"
+    echo "  To package with non-redistributable libraries"
+    echo "    -p|--pack noredist|NOREDIST"
+    echo "  To build a package for a distribution (mandatory)"
+    echo "    -d|--distribution centos7|centos63|fedora20|fedora21"
+    echo "  To set the package release version (optional)"
+    echo "  (default is 1 for normal and prereleases, empty for SNAPSHOT)"
+    echo "    -r|--release version(integer)"
+    echo "  To build for Simulator (optional)"
+    echo "    -s|--simulator default|DEFAULT|simulator|SIMULATOR"
+    echo "  To display this information"
+    echo "    -h|--help"
+    echo ""
+    echo "Examples: ./package.sh --pack oss"
+    echo "          ./package.sh --pack noredist"
+    echo "          ./package.sh --pack oss --distribution centos7 --release 42"
+    echo "          ./package.sh --distribution centos7 --release 42"
+    echo "          ./package.sh --distribution centos7"
+}
+
+# packaging
+#   $1 redist flag
+#   $2 simulator flag
+#   $3 distribution name
+#   $4 package release version
+function packaging() {
+    CWD=$(pwd)/..
+    RPMDIR=$CWD/dist/rpmbuild
+    PACK_PROJECT=cloudstack
+    if [ -n "$1" ] ; then
+        DEFOSSNOSS="-D_ossnoss $1"
+    fi
+    if [ -n "$2" ] ; then
+        DEFSIM="-D_sim $2"
+    fi
+
+    DISTRO=$3
+    MVN=$(which mvn)
+    if [ -z "$MVN" ] ; then
+        MVN=$(locate bin/mvn | grep -e mvn$ | tail -1)
+        if [ -z "$MVN" ] ; then
+            echo -e "mvn not found\n cannot retrieve version to package\n RPM Build Failed"
+            exit 2
+        fi
+    fi
+    VERSION=$(cd ../; $MVN org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep --color=none '^[0-9]\.')
+    if echo "$VERSION" | grep -q SNAPSHOT ; then
+        REALVER=$(echo "$VERSION" | cut -d '-' -f 1)
+        if [ -n "$4" ] ; then
+            DEFPRE="-D_prerelease $4"
+            DEFREL="-D_rel SNAPSHOT$4"
+        else
+            DEFPRE="-D_prerelease 1"
+            DEFREL="-D_rel SNAPSHOT"
+        fi
+    else
+        REALVER="$VERSION"
+        if [ -n "$4" ] ; then
+            DEFREL="-D_rel $4"
+        else
+            DEFREL="-D_rel 1"
+        fi
+    fi
+    DEFVER="-D_ver $REALVER"
+
+    echo "Preparing to package Cosmic $VERSION"
+
+    mkdir -p "$RPMDIR/SPECS"
+    mkdir -p "$RPMDIR/BUILD"
+    mkdir -p "$RPMDIR/RPMS"
+    mkdir -p "$RPMDIR/SRPMS"
+    mkdir -p "$RPMDIR/SOURCES/$PACK_PROJECT-$VERSION"
+
+    echo ". preparing source tarball"
+    (cd ../; tar -c --exclude .git --exclude dist . | tar -C "$RPMDIR/SOURCES/$PACK_PROJECT-$VERSION" -x )
+    (cd "$RPMDIR/SOURCES/"; tar -czf "$PACK_PROJECT-$VERSION.tgz" "$PACK_PROJECT-$VERSION")
+
+    echo ". executing rpmbuild"
+    cp "$DISTRO/cloud.spec" "$RPMDIR/SPECS"
+
+    (cd "$RPMDIR"; rpmbuild --define "_topdir ${RPMDIR}" "${DEFVER}" "${DEFREL}" ${DEFPRE+"$DEFPRE"} ${DEFOSSNOSS+"$DEFOSSNOSS"} ${DEFSIM+"$DEFSIM"} -bb SPECS/cloud.spec)
+    if [ $? -ne 0 ]; then
+        echo "RPM Build Failed "
+        exit 3
+    else
+        echo "RPM Build Done"
+    fi
+    exit
+}
+
+TARGETDISTRO=""
+SIM=""
+PACKAGEVAL=""
+RELEASE=""
+
+SHORTOPTS="hp:s:d:r:"
+LONGOPTS="help,pack:simulator:distribution:release:"
+ARGS=$(getopt -s bash -u -a --options "$SHORTOPTS"  --longoptions "$LONGOPTS" --name "$0" -- "$@")
+eval set -- "$ARGS"
+echo "$ARGS"
+while [ $# -gt 0 ] ; do
+    case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -p | --pack)
+            echo "Packaging Cosmic..."
+            PACKAGEVAL=$2
+            echo "$PACKAGEVAL"
+            if [ "$PACKAGEVAL" == "oss" -o "$PACKAGEVAL" == "OSS" ] ; then
+                PACKAGEVAL=""
+            elif [ "$PACKAGEVAL" == "noredist" -o "$PACKAGEVAL" == "NOREDIST" ] ; then
+                PACKAGEVAL="noredist"
+            else
+                echo "Error: Unsupported value for --pack"
+                usage
+                exit 1
+            fi
+            shift
+            ;;
+        -s | --simulator)
+            SIM=$2
+            echo "$SIM"
+            if [ "$SIM" == "default" -o "$SIM" == "DEFAULT" ] ; then
+                SIM="false"
+            elif [ "$SIM" == "simulator" -o "$SIM" == "SIMULATOR" ] ; then
+                SIM="simulator"
+            else
+                echo "Error: Unsupported value for --simulator"
+                usage
+                exit 1
+            fi
+            shift
+            ;;
+        -d | --distribution)
+            TARGETDISTRO=$2
+            if [ -z "$TARGETDISTRO" ] ; then
+                echo "Error: Missing target distribution"
+                usage
+                exit 1
+            fi
+            shift
+            ;;
+        -r | --release)
+            RELEASE=$2
+            shift
+            ;;
+        -)
+            echo "Error: Unrecognized option"
+            usage
+            exit 1
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+packaging "$PACKAGEVAL" "$SIM" "$TARGETDISTRO" "$RELEASE"
+

--- a/packaging/systemd/cloudstack-agent.service
+++ b/packaging/systemd/cloudstack-agent.service
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[Unit]
+Description=CloudStack Agent
+Documentation=http://www.cloudstack.org/
+Requires=libvirtd.service
+After=libvirtd.service
+
+[Service]
+Type=simple
+Environment=JAVA_HOME=/usr/lib/jvm/jre
+Environment=JAVA_HEAP_INITIAL=256m
+Environment=JAVA_HEAP_MAX=2048m
+Environment=JAVA_CLASS=com.cloud.agent.AgentShell
+ExecStart=/bin/sh -ec '\
+    export ACP=`ls /usr/share/cloudstack-agent/lib/*.jar /usr/share/cloudstack-agent/plugins/*.jar 2>/dev/null|tr "\\n" ":"`; \
+    export CLASSPATH="$ACP:/etc/cloudstack/agent:/usr/share/cloudstack-common/scripts"; \
+    ${JAVA_HOME}/bin/java -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} -cp "$CLASSPATH" $JAVA_CLASS'
+Restart=always
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/cloudstack-usage.service
+++ b/packaging/systemd/cloudstack-usage.service
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[Unit]
+Description=CloudStack Usage Server
+Documentation=http://www.cloudstack.org/
+Wants=network.target network-online.target
+After=network.target network-online.target
+
+[Service]
+Type=simple
+Environment=JAVA_HOME=/usr/lib/jvm/jre
+Environment=JAVA_HEAP_INITIAL=256m
+Environment=JAVA_HEAP_MAX=2048m
+Environment=JAVA_CLASS=com.cloud.usage.UsageServer
+ExecStart=/bin/sh -ec '\
+    export UCP=`ls /usr/share/cloudstack-usage/cloud-usage-*.jar /usr/share/cloudstack-usage/lib/*.jar | tr "\\n" ":"`; \
+    export CLASSPATH="$UCP:/etc/cloudstack/usage:/usr/share/java/mysql-connector-java.jar"; \
+    ${JAVA_HOME}/bin/java -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} -cp "$CLASSPATH" $JAVA_CLASS'
+Restart=always
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The packaging directory has to be under the directory where the build should it start. When `rpmbuild` runs, from within packaging, it will use the upper-directory, in that case `cosmic` as base to access the other directories: `cosmic-core` and it's sub-dirs.

I also replaced CloudStack by Cosmic in many files. The packages names remain cloudstack because changing them created problems. In order to do that, we have to look more carefully at what we have to change.
