### PR TITLE
Add dependency management to parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,6 @@
     <cs.logging.version>1.1.1</cs.logging.version>
     <cs.discovery.version>0.5</cs.discovery.version>
     <cs.ejb.version>3.0</cs.ejb.version>
-    <!-- do not forget to also upgrade hamcrest library with junit -->
-    <cs.junit.version>4.11</cs.junit.version>
-    <cs.hamcrest.version>1.3</cs.hamcrest.version>
     <cs.bcprov.version>1.46</cs.bcprov.version>
     <cs.jsch.version>0.1.51</cs.jsch.version>
     <cs.jpa.version>2.1.0</cs.jpa.version>
@@ -61,12 +58,10 @@
     <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
     <cs.vmware.api.version>5.5</cs.vmware.api.version>
     <org.springframework.version>3.2.12.RELEASE</org.springframework.version>
-    <cs.mockito.version>1.9.5</cs.mockito.version>
     <cs.powermock.version>1.5.3</cs.powermock.version>
     <cs.aws.sdk.version>1.10.34</cs.aws.sdk.version>
     <cs.jackson.version>2.6.3</cs.jackson.version>
     <cs.lang.version>2.6</cs.lang.version>
-    <cs.commons-lang3.version>3.4</cs.commons-lang3.version>
     <cs.commons-io.version>2.4</cs.commons-io.version>
     <cs.commons-validator.version>1.4.0</cs.commons-validator.version>
     <cs.reflections.version>0.9.9</cs.reflections.version>
@@ -83,6 +78,7 @@
     <cs.opensaml.version>2.6.1</cs.opensaml.version>
     <cs.xml-apis.version>1.4.01</cs.xml-apis.version>
     <cs.joda-time.version>2.8.1</cs.joda-time.version>
+    <cs.hamcrest.version>1.3</cs.hamcrest.version>
   </properties>
 
   <licenses>
@@ -108,9 +104,326 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-all</artifactId>
+        <version>${cs.hamcrest.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>${cs.hamcrest.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-all</artifactId>
+        <version>1.9.5</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>hamcrest-core</artifactId>
+            <groupId>org.hamcrest</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.11</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>hamcrest-core</artifactId>
+            <groupId>org.hamcrest</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>${cs.powermock.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>${cs.powermock.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-test</artifactId>
+        <version>${org.springframework.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.inject</groupId>
+        <artifactId>javax.inject</artifactId>
+        <version>1</version>
+      </dependency>
+
+      <!-- go throught these dependencies and evaluate where they should 
+        be -->
+      <dependency>
+        <groupId>mysql</groupId>
+        <artifactId>mysql-connector-java</artifactId>
+        <version>${cs.mysql.version}</version>
+        <scope>provided,test</scope>
+      </dependency>
+      <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>${cs.log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
+        <version>${org.springframework.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>cglib</groupId>
+        <artifactId>cglib-nodep</artifactId>
+        <version>${cs.cglib.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-dbcp</groupId>
+        <artifactId>commons-dbcp</artifactId>
+        <version>${cs.dbcp.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>commons-pool</artifactId>
+            <groupId>commons-pool</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>net.sf.ehcache</groupId>
+        <artifactId>ehcache-core</artifactId>
+        <version>${cs.ehcache.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-pool</groupId>
+        <artifactId>commons-pool</artifactId>
+        <version>${cs.pool.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>${cs.codec.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-validator</groupId>
+        <artifactId>commons-validator</artifactId>
+        <version>${cs.commons-validator.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk16</artifactId>
+        <version>${cs.bcprov.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.jcraft</groupId>
+        <artifactId>jsch</artifactId>
+        <version>${cs.jsch.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jasypt</groupId>
+        <artifactId>jasypt</artifactId>
+        <version>${cs.jasypt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.trilead</groupId>
+        <artifactId>trilead-ssh2</artifactId>
+        <version>${cs.trilead.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk</artifactId>
+        <version>${cs.aws.sdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>apache-log4j-extras</artifactId>
+        <version>${cs.log4j.extras.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>log4j</artifactId>
+            <groupId>log4j</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>javax.ejb</groupId>
+        <artifactId>ejb-api</artifactId>
+        <version>${cs.ejb.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.googlecode.java-ipv6</groupId>
+        <artifactId>java-ipv6</artifactId>
+        <version>${cs.java-ipv6.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-configuration</groupId>
+        <artifactId>commons-configuration</artifactId>
+        <version>${cs.configuration.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${cs.commons-io.version}</version>
+      </dependency>
+      <!-- Test dependency in mysql for db tests -->
+      <dependency>
+        <groupId>org.reflections</groupId>
+        <artifactId>reflections</artifactId>
+        <version>${cs.reflections.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.owasp.esapi</groupId>
+        <artifactId>esapi</artifactId>
+        <version>2.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.persistence</groupId>
+        <artifactId>javax.persistence</artifactId>
+        <version>${cs.jpa.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>${org.springframework.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>servlet-api</artifactId>
+        <version>${cs.servlet.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>${cs.httpcore.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${cs.httpclient.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.thoughtworks.xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <version>${cs.xstream.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.mail</groupId>
+        <artifactId>mail</artifactId>
+        <version>${cs.mail.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>jstl</groupId>
+        <artifactId>jstl</artifactId>
+        <version>${cs.jstl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-aop</artifactId>
+        <version>${org.springframework.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <version>${org.springframework.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>${cs.gson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${cs.guava.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.aspectj</groupId>
+        <artifactId>aspectjtools</artifactId>
+        <version>1.8.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.aspectj</groupId>
+        <artifactId>aspectjweaver</artifactId>
+        <version>1.8.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.axis</groupId>
+        <artifactId>axis</artifactId>
+        <version>${cs.axis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-daemon</groupId>
+        <artifactId>commons-daemon</artifactId>
+        <version>${cs.daemon.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.axis</groupId>
+        <artifactId>axis-jaxrpc</artifactId>
+        <version>${cs.axis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>wsdl4j</groupId>
+        <artifactId>wsdl4j</artifactId>
+        <version>1.6.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <version>1.7.7</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+    </dependency>
+  </dependencies>
 
   <build>
     <defaultGoal>install</defaultGoal>
@@ -209,6 +522,192 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>2.18.1</version>
         </plugin>
+
+        <!-- TODO: review the follwoing plugins to evaluate if they should 
+          be here -->
+        <plugin>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${cs.mycila.license.version}</version>
+          <executions>
+            <execution>
+              <id>cosmic-checklicence</id>
+              <phase>process-classes</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <strictCheck>true</strictCheck>
+            <aggregate>true</aggregate>
+            <header>../LICENSE.header</header>
+            <mapping>
+              <xml>XML_STYLE</xml>
+              <java>DOUBLESLASH_STYLE</java>
+              <clj>SEMICOLON_STYLE</clj>
+            </mapping>
+            <useDefaultExcludes>false</useDefaultExcludes>
+            <excludes>
+              <exclude>**/target/**</exclude>
+              <exclude>.settings/**</exclude>
+              <exclude>.checkstyle</exclude>
+              <exclude>.project</exclude>
+              <exclude>.classpath</exclude>
+              <exclude>.pmd*</exclude>
+            </excludes>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.rat</groupId>
+          <artifactId>apache-rat-plugin</artifactId>
+          <configuration>
+            <numUnapprovedLicenses>0</numUnapprovedLicenses>
+            <excludeSubProjects>false</excludeSubProjects>
+            <excludes>
+              <exclude>CHANGES.md</exclude>
+              <exclude>README.md</exclude>
+              <exclude>INSTALL.md</exclude>
+              <exclude>CONTRIBUTING.md</exclude>
+              <exclude>tools/docker/Dockerfile</exclude>
+              <exclude>tools/docker/supervisord.conf</exclude>
+              <exclude>.idea/</exclude>
+              <exclude>**/*.log</exclude>
+              <exclude>**/*.patch</exclude>
+              <exclude>**/.classpath</exclude>
+              <exclude>**/.project</exclude>
+              <exclude>**/.idea/**</exclude>
+              <exclude>**/*.iml</exclude>
+              <exclude>**/.settings/**</exclude>
+              <exclude>.metadata/**</exclude>
+              <exclude>.git/**</exclude>
+              <exclude>.gitignore</exclude>
+              <exclude>**/*.crt</exclude>
+              <exclude>**/*.csr</exclude>
+              <exclude>**/*.key</exclude>
+              <exclude>**/authorized_keys</exclude>
+              <exclude>**/*.war</exclude>
+              <exclude>**/*.mar</exclude>
+              <exclude>**/*.jar</exclude>
+              <exclude>**/*.iso</exclude>
+              <exclude>**/*.tgz</exclude>
+              <exclude>**/*.zip</exclude>
+              <exclude>**/target/**</exclude>
+              <exclude>**/.vagrant</exclude>
+              <exclude>**/*.json</exclude>
+              <exclude>build/build.number</exclude>
+              <exclude>services/console-proxy/server/js/jquery.js</exclude>
+              <exclude>debian/compat</exclude>
+              <exclude>debian/control</exclude>
+              <exclude>debian/dirs</exclude>
+              <exclude>debian/rules</exclude>
+              <exclude>debian/source/format</exclude>
+              <exclude>dist/console-proxy/js/jquery.js</exclude>
+              <exclude>plugins/hypervisors/hyperv/DotNet/ServerResource/ServerResource.sln</exclude>
+              <exclude>plugins/hypervisors/hyperv/DotNet/ServerResource/packages/**</exclude>
+              <exclude>plugins/hypervisors/hyperv/DotNet/ServerResource/.nuget/**</exclude>
+              <exclude>plugins/hypervisors/hyperv/DotNet/ServerResource/**/obj/**</exclude>
+              <exclude>plugins/hypervisors/hyperv/DotNet/ServerResource/**/bin/**</exclude>
+              <exclude>plugins/hypervisors/hyperv/DotNet/ServerResource/**/packages.config</exclude>
+              <exclude>plugins/hypervisors/hyperv/DotNet/ServerResource/**/App.config</exclude>
+              <exclude>plugins/hypervisors/hyperv/DotNet/ServerResource/**/*.csproj</exclude>
+              <exclude>plugins/hypervisors/hyperv/DotNet/ServerResource/**/*.settings</exclude>
+              <exclude>plugins/hypervisors/hyperv/conf/agent.properties</exclude>
+              <exclude>scripts/vm/systemvm/id_rsa.cloud</exclude>
+              <exclude>services/console-proxy/server/conf/agent.properties</exclude>
+              <exclude>services/console-proxy/server/conf/environment.properties</exclude>
+              <exclude>services/secondary-storage/conf/agent.properties</exclude>
+              <exclude>services/secondary-storage/conf/environment.properties</exclude>
+              <exclude>test/systemvm/README.md</exclude>
+              <exclude>tools/appliance/.ruby-version</exclude>
+              <exclude>tools/vagrant/systemvm/vagrant.pub</exclude>
+              <exclude>tools/vagrant/systemvm/.ruby-version</exclude>
+              <exclude>tools/appliance/definitions/systemvmtemplate/*</exclude>
+              <exclude>tools/appliance/definitions/systemvm64template/*</exclude>
+              <exclude>tools/appliance/definitions/builtin/*</exclude>
+              <exclude>tools/cli/cloudmonkey.egg-info/*</exclude>
+              <exclude>tools/marvin/Marvin.egg-info/*</exclude>
+              <exclude>systemvm/conf/agent.properties</exclude>
+              <exclude>systemvm/conf/environment.properties</exclude>
+              <exclude>systemvm/js/jquery.js</exclude>
+              <exclude>systemvm/patches/debian/systemvm.vmx</exclude>
+              <exclude>systemvm/patches/debian/config/root/.ssh/authorized_keys</exclude>
+              <exclude>systemvm/patches/debian/config/etc/apache2/httpd.conf</exclude>
+              <exclude>systemvm/patches/debian/config/etc/apache2/ports.conf</exclude>
+              <exclude>systemvm/patches/debian/config/etc/apache2/sites-available/default</exclude>
+              <exclude>systemvm/patches/debian/config/etc/apache2/sites-available/default-ssl</exclude>
+              <exclude>systemvm/patches/debian/config/etc/apache2/vhostexample.conf</exclude>
+              <exclude>systemvm/patches/debian/config/etc/dnsmasq.conf.tmpl</exclude>
+              <exclude>systemvm/patches/debian/config/etc/vpcdnsmasq.conf</exclude>
+              <exclude>systemvm/patches/debian/config/etc/ssh/sshd_config</exclude>
+              <exclude>systemvm/patches/debian/config/etc/rsyslog.conf</exclude>
+              <exclude>systemvm/patches/debian/config/etc/logrotate.conf</exclude>
+              <exclude>systemvm/patches/debian/config/etc/logrotate.d/*</exclude>
+              <exclude>systemvm/patches/debian/config/etc/sysctl.conf</exclude>
+              <exclude>systemvm/patches/debian/config/root/redundant_router/keepalived.conf.templ</exclude>
+              <exclude>systemvm/patches/debian/config/root/redundant_router/arping_gateways.sh.templ</exclude>
+              <exclude>systemvm/patches/debian/config/root/redundant_router/conntrackd.conf.templ</exclude>
+              <exclude>systemvm/patches/debian/vpn/etc/ipsec.conf</exclude>
+              <exclude>systemvm/patches/debian/vpn/etc/ppp/options.xl2tpd</exclude>
+              <exclude>systemvm/patches/debian/vpn/etc/xl2tpd/xl2tpd.conf</exclude>
+              <exclude>systemvm/patches/debian/vpn/etc/ipsec.secrets</exclude>
+              <exclude>systemvm/patches/debian/config/etc/haproxy/haproxy.cfg</exclude>
+              <exclude>systemvm/patches/debian/config/etc/cloud-nic.rules</exclude>
+              <exclude>systemvm/patches/debian/config/etc/modprobe.d/aesni_intel</exclude>
+              <exclude>systemvm/patches/debian/config/etc/rc.local</exclude>
+              <exclude>systemvm/patches/debian/config/var/www/html/userdata/.htaccess</exclude>
+              <exclude>systemvm/patches/debian/config/var/www/html/latest/.htaccess</exclude>
+              <exclude>systemvm/patches/debian/vpn/etc/ipsec.d/l2tp.conf</exclude>
+              <exclude>tools/transifex/.tx/config</exclude>
+              <exclude>tools/logo/apache_cloudstack.png</exclude>
+              <exclude>tools/marvin/marvin/sandbox/advanced/sandbox.cfg</exclude>
+              <exclude>tools/ngui/static/bootstrap/*</exclude>
+              <exclude>tools/ngui/static/js/lib/*</exclude>
+              <exclude>**/.checkstyle</exclude>
+              <exclude>**/*.md</exclude>
+            </excludes>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.5</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+              </manifest>
+            </archive>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>1.9.1</version>
+          <executions>
+            <execution>
+              <id>remove-old-installers</id>
+              <goals>
+                <goal>remove-project-artifact</goal>
+              </goals>
+              <configuration>
+                <removeAll>true</removeAll>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>cobertura-maven-plugin</artifactId>
+          <configuration>
+            <formats>
+              <format>html</format>
+              <format>xml</format>
+            </formats>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -219,5 +718,5 @@
         <module>cosmic-core</module>
       </modules>
     </profile>
-   </profiles>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -427,20 +427,6 @@
 
   <build>
     <defaultGoal>install</defaultGoal>
-    <sourceDirectory>src</sourceDirectory>
-    <testSourceDirectory>test</testSourceDirectory>
-    <resources>
-      <resource>
-        <directory>${basedir}/resources</directory>
-      </resource>
-    </resources>
-    <testResources>
-      <testResource>
-        <directory>test/resources</directory>
-      </testResource>
-    </testResources>
-    <outputDirectory>${basedir}/${cs.target.dir}/classes</outputDirectory>
-    <testOutputDirectory>${basedir}/${cs.target.dir}/test-classes</testOutputDirectory>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <artifactId>cosmic</artifactId>
   <version>5.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>Cosmic</name>
+  <name>Cosmic (Parent)</name>
   <description>Cosmic is an IaaS (“Infrastructure as a Service”) cloud orchestration platform.</description>
   <url>http://www.cosmic.cloud</url>
 


### PR DESCRIPTION
This PR addresses some issues with building the project, namely that dependency management should be at this level, shared dependencies should also be defined at this level (to avoid redeclaration in modules), and redefinition of default maven directories is not needed anymore.
It also redefines the name of the artifact to Cosmic (Parent).
