### PR TITLE
Adds packaging to git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ vmops.log*
 
 # Packaging directory
 packaging/
+cosmic-packaging/

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ dist/
 # Management Server logs
 api.log
 vmops.log*
+
+# Packaging directory
+packaging/


### PR DESCRIPTION
We have to build the RPMs from the cosmic directory, that's why we clone it under cosmic and have it on gitignore to avoid problems.
