### PR TITLE
Prepare pom for next development version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ vmops.log*
 # Packaging directory
 packaging/
 cosmic-packaging/
+
+#PyDev settings
+.pydevproject

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>cloud.cosmic</groupId>
   <artifactId>cosmic</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>5.0.0.0</version>
   <packaging>pom</packaging>
   <name>Cosmic</name>
   <description>Cosmic is an IaaS (“Infrastructure as a Service”) cloud orchestration platform.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -448,9 +448,19 @@
     </dependency>
   </dependencies>
 
+  <scm>
+    <connection>scm:git:git@github.com:MissionCriticalCloud/cosmic.git</connection>
+    <developerConnection>scm:git:git@github.com:MissionCriticalCloud/cosmic.git</developerConnection>
+  </scm>
+
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+        </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <configuration>
@@ -477,22 +487,6 @@
               </fileset>
             </filesets>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.1</version>
-          <executions>
-            <execution>
-              <id>default</id>
-              <goals>
-                <goal>perform</goal>
-              </goals>
-              <configuration>
-                <pomFileName>pom.xml</pomFileName>
-              </configuration>
-            </execution>
-          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -779,8 +773,8 @@
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
             <executions>
-              <!-- Prepares the property pointing to the JaCoCo runtime agent which is passed as VM argument when unit tests 
-                run. -->
+              <!-- Prepares the property pointing to the JaCoCo runtime agent which 
+                is passed as VM argument when unit tests run. -->
               <execution>
                 <id>setup-unit-tests-javaagent</id>
                 <phase>test-compile</phase>
@@ -790,7 +784,8 @@
                 <configuration>
                   <!-- Sets the path to the file which contains the execution data. -->
                   <destFile>${unit.tests.report}</destFile>
-                  <!-- Sets the name of the property containing the settings for JaCoCo runtime agent. -->
+                  <!-- Sets the name of the property containing the settings for 
+                    JaCoCo runtime agent. -->
                   <propertyName>surefireArgLine</propertyName>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>cloud.cosmic</groupId>
   <artifactId>cosmic</artifactId>
-  <version>5.0.0.0</version>
+  <version>5.0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Cosmic</name>
   <description>Cosmic is an IaaS (“Infrastructure as a Service”) cloud orchestration platform.</description>


### PR DESCRIPTION
The Cosmic parent pom is now set to 5.0.0.1-SNAPSHOT, which will fix the tracking build on Jenkins since it aligned with the su-modules versions.
