### PR TITLE
Have maven skip javadoc generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
   </prerequisites>
 
   <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
     <cs.jdk.version>1.8</cs.jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Setting the maven.javadoc.skip property to true will prevent the
javadoc generation to run while preparing for a release
