### PR TITLE
Bump mariadb-java-client to 1.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
       <dependency>
         <groupId>org.mariadb.jdbc</groupId>
         <artifactId>mariadb-java-client</artifactId>
-        <version>1.4.0</version>
+        <version>1.4.3</version>
       </dependency>
 
       <!-- go throught these dependencies and evaluate where they should be -->


### PR DESCRIPTION
This resolves an issue with inserting ACL items:

```
com.cloud.utils.exception.CloudRuntimeException: DB Exception on: sql : 'INSERT INTO network_acl_item_cidrs (network_acl_item_cidrs.network_acl_item_id, network_acl_item_cidrs.cidr) VALUES (?, ?)', parameters : [-28246,<bytearray> 10.1.0.0/20]
...
Out of range value for column 'network_acl_item_id' at row 1
```
