### PR TITLE
Revert "[maven-release-plugin] prepare release cosmic-5.0.1.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>cloud.cosmic</groupId>
   <artifactId>cosmic</artifactId>
-  <version>5.0.1.2</version>
+  <version>5.0.1.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Cosmic</name>
   <description>Cosmic is an IaaS (“Infrastructure as a Service”) cloud orchestration platform.</description>
@@ -468,7 +468,7 @@
   <scm>
     <connection>scm:git:git@github.com:MissionCriticalCloud/cosmic.git</connection>
     <developerConnection>scm:git:git@github.com:MissionCriticalCloud/cosmic.git</developerConnection>
-    <tag>cosmic-5.0.1.2</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
This reverts commit 1f34613cfa82a4748ca360952b39e97539e80a84.

The packaging was broken due to this commit. 

```
23:08:08 [INFO] Creating source code tar (from /data/jenkins-slave/workspace/cosmic/0002-tracking-repo-branch-build)
23:10:45 error: File /data/jenkins-slave/workspace/cosmic/1000-rpm-package/dist/rpmbuild/ is not a regular file.
23:10:45 RPM Build Failed 
23:10:45 Build step 'Execute shell' marked build as failure
```

Without this commit it works again:

```
+ echo 'RPM Build Done'
RPM Build Done
+ exit
```

Looks like a broken release attempt that wasn't fully completed.
