### PR TITLE
Remove dependency version properties from cosmic-core pom.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <maven.javadoc.skip>true</maven.javadoc.skip>
-    <cs.jdk.version>1.8</cs.jdk.version>
+    <cs.jdk.version>1.7</cs.jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
These properties are already defined in the top-level cosmic pom. Before, the java version property was set in the cosmic-core. Now we define it here.

Integration tests succeeded: https://beta-jenkins.mcc.schubergphilis.com/job/cosmic/job/0002-tracking-repo-branch-build/128/

Merge together with: https://github.com/MissionCriticalCloud/cosmic-core/pull/183
