### PR TITLE
Upgrade to Java 8 and Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <cs.axis-jaxrpc.version>1.4</cs.axis-jaxrpc.version>
     <cs.axis.version>1.4</cs.axis.version>
     <cs.bcprov-jdk16.version>1.46</cs.bcprov-jdk16.version>
-    <cs.cglib-nodep.version>3.1</cs.cglib-nodep.version>
+    <cs.cglib-nodep.version>3.2.2</cs.cglib-nodep.version>
     <cs.commons-codec.version>1.10</cs.commons-codec.version>
     <cs.commons-configuration.version>1.10</cs.commons-configuration.version>
     <cs.commons-daemon.version>1.0.15</cs.commons-daemon.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,13 @@
     <maven>3.0.4</maven>
   </prerequisites>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>1.3.5.RELEASE</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+
   <properties>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <cs.jdk.version>1.8</cs.jdk.version>
@@ -69,11 +76,10 @@
     <cs.rampart.version>1.5.1</cs.rampart.version>
     <cs.axiom.version>1.2.8</cs.axiom.version>
     <cs.neethi.version>2.0.4</cs.neethi.version>
-    <cs.servlet.version>2.5</cs.servlet.version>
+    <cs.servlet.version>3.1.0</cs.servlet.version>
     <cs.jstl.version>1.2</cs.jstl.version>
     <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
-    <org.springframework.version>3.2.12.RELEASE</org.springframework.version>
-    <cs.powermock.version>1.5.3</cs.powermock.version>
+    <cs.powermock.version>1.6.4</cs.powermock.version>
     <cs.aws.sdk.version>1.10.34</cs.aws.sdk.version>
     <cs.jackson.version>2.6.3</cs.jackson.version>
     <cs.lang.version>2.6</cs.lang.version>
@@ -164,7 +170,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
-        <version>1.9.5</version>
+        <version>1.10.19</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -176,7 +182,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -194,12 +200,6 @@
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-mockito</artifactId>
         <version>${cs.powermock.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-test</artifactId>
-        <version>${org.springframework.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -224,11 +224,6 @@
         <groupId>log4j</groupId>
         <artifactId>log4j</artifactId>
         <version>${cs.log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-context</artifactId>
-        <version>${org.springframework.version}</version>
       </dependency>
       <dependency>
         <groupId>cglib</groupId>
@@ -339,13 +334,8 @@
         <version>${cs.jpa.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-web</artifactId>
-        <version>${org.springframework.version}</version>
-      </dependency>
-      <dependency>
         <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
+        <artifactId>javax.servlet-api</artifactId>
         <version>${cs.servlet.version}</version>
       </dependency>
       <dependency>
@@ -372,16 +362,6 @@
         <groupId>jstl</groupId>
         <artifactId>jstl</artifactId>
         <version>${cs.jstl.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-aop</artifactId>
-        <version>${org.springframework.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-beans</artifactId>
-        <version>${org.springframework.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,20 +39,24 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+    <cs.replace.properties>build/replace.properties</cs.replace.properties>
+    <cs.target.dir>target</cs.target.dir>
+
     <coverage.reports.dir>${cosmic.dir}/target/coverage-reports</coverage.reports.dir>
     <unit.tests.report>${coverage.reports.dir}/jacoco-ut.exec</unit.tests.report>
     <integration.tests.report>${coverage.reports.dir}/jacoco-it.exec</integration.tests.report>
 
-    <cs.log4j.version>1.2.17</cs.log4j.version>
+
+    <!-- Pinned older version than Spring 4 dependency management -->
+    <cs.gson.version>1.7.2</cs.gson.version>
+
+
+    <!-- Check below deps for latest version -->
     <cs.log4j.extras.version>1.2.17</cs.log4j.extras.version>
     <cs.cglib.version>3.1</cs.cglib.version>
-    <cs.dbcp.version>1.4</cs.dbcp.version>
-    <cs.pool.version>1.6</cs.pool.version>
     <cs.codec.version>1.10</cs.codec.version>
+    <cs.codec.net>3.3</cs.codec.net>
     <cs.configuration.version>1.10</cs.configuration.version>
-    <cs.collections.version>3.2.2</cs.collections.version>
-    <cs.logging.version>1.1.1</cs.logging.version>
-    <cs.discovery.version>0.5</cs.discovery.version>
     <cs.ejb.version>3.0</cs.ejb.version>
     <cs.bcprov.version>1.46</cs.bcprov.version>
     <cs.jsch.version>0.1.51</cs.jsch.version>
@@ -60,46 +64,30 @@
     <cs.jasypt.version>1.9.2</cs.jasypt.version>
     <cs.trilead.version>1.0.0-build217</cs.trilead.version>
     <cs.ehcache.version>2.6.9</cs.ehcache.version>
-    <cs.gson.version>1.7.2</cs.gson.version>
-    <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
     <cs.guava.version>18.0</cs.guava.version>
     <cs.xapi.version>6.2.0-3.1</cs.xapi.version>
-    <cs.httpclient.version>4.5</cs.httpclient.version>
-    <cs.httpcore.version>4.4</cs.httpcore.version>
-    <cs.commons-httpclient.version>3.1</cs.commons-httpclient.version>
     <cs.mysql.version>5.1.34</cs.mysql.version>
     <cs.xstream.version>1.4.7</cs.xstream.version>
     <cs.xmlrpc.version>3.1.3</cs.xmlrpc.version>
     <cs.mail.version>1.4.7</cs.mail.version>
     <cs.axis.version>1.4</cs.axis.version>
-    <cs.axis2.version>1.5.6</cs.axis2.version>
-    <cs.rampart.version>1.5.1</cs.rampart.version>
-    <cs.axiom.version>1.2.8</cs.axiom.version>
-    <cs.neethi.version>2.0.4</cs.neethi.version>
-    <cs.servlet.version>3.1.0</cs.servlet.version>
-    <cs.jstl.version>1.2</cs.jstl.version>
     <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
     <cs.powermock.version>1.6.4</cs.powermock.version>
     <cs.aws.sdk.version>1.10.34</cs.aws.sdk.version>
-    <cs.jackson.version>2.6.3</cs.jackson.version>
-    <cs.lang.version>2.6</cs.lang.version>
     <cs.commons-io.version>2.4</cs.commons-io.version>
     <cs.commons-validator.version>1.4.0</cs.commons-validator.version>
     <cs.reflections.version>0.9.9</cs.reflections.version>
     <cs.java-ipv6.version>0.15</cs.java-ipv6.version>
-    <cs.replace.properties>build/replace.properties</cs.replace.properties>
     <cs.libvirt-java.version>0.5.1</cs.libvirt-java.version>
     <cs.rados-java.version>0.2.0</cs.rados-java.version>
-    <cs.target.dir>target</cs.target.dir>
     <cs.daemon.version>1.0.15</cs.daemon.version>
     <cs.jna.version>4.0.0</cs.jna.version>
-    <cs.mycila.license.version>2.7</cs.mycila.license.version>
-    <cs.findbugs.version>3.0.1</cs.findbugs.version>
-    <cs.javadoc.version>2.10.1</cs.javadoc.version>
     <cs.opensaml.version>2.6.1</cs.opensaml.version>
     <cs.xml-apis.version>1.4.01</cs.xml-apis.version>
-    <cs.joda-time.version>2.8.1</cs.joda-time.version>
     <cs.hamcrest.version>1.3</cs.hamcrest.version>
+    <cs.jstl.version>1.2</cs.jstl.version>
+    <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
+    <cs.mycila.license.version>2.7</cs.mycila.license.version>
   </properties>
 
   <licenses>
@@ -141,6 +129,16 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>jstl</groupId>
+        <artifactId>jstl</artifactId>
+        <version>${cs.jstl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-testlib</artifactId>
+        <version>${cs.guava-testlib.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.jacoco</groupId>
         <artifactId>org.jacoco.agent</artifactId>
         <version>0.7.6.201602180812</version>
@@ -158,12 +156,6 @@
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-all</artifactId>
-        <version>${cs.hamcrest.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
         <version>${cs.hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
@@ -221,25 +213,9 @@
         <scope>provided,test</scope>
       </dependency>
       <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>${cs.log4j.version}</version>
-      </dependency>
-      <dependency>
         <groupId>cglib</groupId>
         <artifactId>cglib-nodep</artifactId>
         <version>${cs.cglib.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-dbcp</groupId>
-        <artifactId>commons-dbcp</artifactId>
-        <version>${cs.dbcp.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>commons-pool</artifactId>
-            <groupId>commons-pool</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>net.sf.ehcache</groupId>
@@ -247,14 +223,14 @@
         <version>${cs.ehcache.version}</version>
       </dependency>
       <dependency>
-        <groupId>commons-pool</groupId>
-        <artifactId>commons-pool</artifactId>
-        <version>${cs.pool.version}</version>
-      </dependency>
-      <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${cs.codec.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-net</groupId>
+        <artifactId>commons-net</artifactId>
+        <version>${cs.codec.net}</version>
       </dependency>
       <dependency>
         <groupId>commons-validator</groupId>
@@ -334,21 +310,6 @@
         <version>${cs.jpa.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>${cs.servlet.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpcore</artifactId>
-        <version>${cs.httpcore.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${cs.httpclient.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
         <version>${cs.xstream.version}</version>
@@ -357,11 +318,6 @@
         <groupId>javax.mail</groupId>
         <artifactId>mail</artifactId>
         <version>${cs.mail.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>jstl</groupId>
-        <artifactId>jstl</artifactId>
-        <version>${cs.jstl.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>
@@ -412,6 +368,51 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
         <version>1.7.7</version>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.vcc.thirdparty</groupId>
+        <artifactId>xen-api</artifactId>
+        <version>${cs.xapi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlrpc</groupId>
+        <artifactId>xmlrpc-client</artifactId>
+        <version>${cs.xmlrpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlrpc</groupId>
+        <artifactId>xmlrpc-common</artifactId>
+        <version>${cs.xmlrpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openqa.selenium.server</groupId>
+        <artifactId>selenium-server</artifactId>
+        <version>${cs.selenium.server.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.libvirt</groupId>
+        <artifactId>libvirt</artifactId>
+        <version>${cs.libvirt-java.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ceph</groupId>
+        <artifactId>rados</artifactId>
+        <version>${cs.rados-java.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>${cs.jna.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.opensaml</groupId>
+        <artifactId>opensaml</artifactId>
+        <version>${cs.opensaml.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>${cs.xml-apis.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -46,48 +46,57 @@
     <unit.tests.report>${coverage.reports.dir}/jacoco-ut.exec</unit.tests.report>
     <integration.tests.report>${coverage.reports.dir}/jacoco-it.exec</integration.tests.report>
 
-
     <!-- Pinned older version than Spring 4 dependency management -->
     <cs.gson.version>1.7.2</cs.gson.version>
 
-
-    <!-- Check below deps for latest version -->
-    <cs.log4j.extras.version>1.2.17</cs.log4j.extras.version>
-    <cs.cglib.version>3.1</cs.cglib.version>
-    <cs.codec.version>1.10</cs.codec.version>
-    <cs.codec.net>3.3</cs.codec.net>
-    <cs.configuration.version>1.10</cs.configuration.version>
-    <cs.ejb.version>3.0</cs.ejb.version>
-    <cs.bcprov.version>1.46</cs.bcprov.version>
-    <cs.jsch.version>0.1.51</cs.jsch.version>
-    <cs.jpa.version>2.1.0</cs.jpa.version>
-    <cs.jasypt.version>1.9.2</cs.jasypt.version>
-    <cs.trilead.version>1.0.0-build217</cs.trilead.version>
-    <cs.ehcache.version>2.6.9</cs.ehcache.version>
-    <cs.guava.version>18.0</cs.guava.version>
-    <cs.xapi.version>6.2.0-3.1</cs.xapi.version>
-    <cs.mysql.version>5.1.34</cs.mysql.version>
-    <cs.xstream.version>1.4.7</cs.xstream.version>
-    <cs.xmlrpc.version>3.1.3</cs.xmlrpc.version>
-    <cs.mail.version>1.4.7</cs.mail.version>
+    <!-- Dependency management properties -->
+    <cs.apache-log4j-extras.version>1.2.17</cs.apache-log4j-extras.version>
+    <cs.aws-java-sdk.version>1.10.34</cs.aws-java-sdk.version>
+    <cs.axis-jaxrpc.version>1.4</cs.axis-jaxrpc.version>
     <cs.axis.version>1.4</cs.axis.version>
-    <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
-    <cs.powermock.version>1.6.4</cs.powermock.version>
-    <cs.aws.sdk.version>1.10.34</cs.aws.sdk.version>
+    <cs.bcprov-jdk16.version>1.46</cs.bcprov-jdk16.version>
+    <cs.cglib-nodep.version>3.1</cs.cglib-nodep.version>
+    <cs.commons-codec.version>1.10</cs.commons-codec.version>
+    <cs.commons-configuration.version>1.10</cs.commons-configuration.version>
+    <cs.commons-daemon.version>1.0.15</cs.commons-daemon.version>
     <cs.commons-io.version>2.4</cs.commons-io.version>
+    <cs.commons-lang3.version>3.4</cs.commons-lang3.version>
+    <cs.commons-net.version>3.3</cs.commons-net.version>
     <cs.commons-validator.version>1.4.0</cs.commons-validator.version>
-    <cs.reflections.version>0.9.9</cs.reflections.version>
-    <cs.java-ipv6.version>0.15</cs.java-ipv6.version>
-    <cs.libvirt-java.version>0.5.1</cs.libvirt-java.version>
-    <cs.rados-java.version>0.2.0</cs.rados-java.version>
-    <cs.daemon.version>1.0.15</cs.daemon.version>
-    <cs.jna.version>4.0.0</cs.jna.version>
-    <cs.opensaml.version>2.6.1</cs.opensaml.version>
-    <cs.xml-apis.version>1.4.01</cs.xml-apis.version>
-    <cs.hamcrest.version>1.3</cs.hamcrest.version>
-    <cs.jstl.version>1.2</cs.jstl.version>
+    <cs.ehcache-core.version>2.6.9</cs.ehcache-core.version>
+    <cs.ejb-api.version>3.0</cs.ejb-api.version>
+    <cs.esapi.version>2.1.0</cs.esapi.version>
     <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
+    <cs.guava.version>18.0</cs.guava.version>
+    <cs.hamcrest-all.version>1.3</cs.hamcrest-all.version>
+    <cs.jasypt.version>1.9.2</cs.jasypt.version>
+    <cs.java-ipv6.version>0.15</cs.java-ipv6.version>
+    <cs.javax.inject.version>1</cs.javax.inject.version>
+    <cs.javax.persistence.version>2.1.0</cs.javax.persistence.version>
+    <cs.jna.version>4.0.0</cs.jna.version>
+    <cs.jsch.version>0.1.51</cs.jsch.version>
+    <cs.jstl.version>1.2</cs.jstl.version>
+    <cs.libvirt.version>0.5.1</cs.libvirt.version>
+    <cs.mail.version>1.4.7</cs.mail.version>
+    <cs.mockito-all.version>1.10.19</cs.mockito-all.version>
     <cs.mycila.license.version>2.7</cs.mycila.license.version>
+    <cs.opensaml.version>2.6.1</cs.opensaml.version>
+    <cs.org.jacoco.agent.rt.version>0.7.6.201602180812</cs.org.jacoco.agent.rt.version>
+    <cs.org.jacoco.agent.version>0.7.6.201602180812</cs.org.jacoco.agent.version>
+    <cs.powermock-api-mockito.version>1.6.4</cs.powermock-api-mockito.version>
+    <cs.powermock-module-junit4.version>1.6.4</cs.powermock-module-junit4.version>
+    <cs.rados.version>0.2.0</cs.rados.version>
+    <cs.reflections.version>0.9.9</cs.reflections.version>
+    <cs.selenium-server.version>1.0-20081010.060147</cs.selenium-server.version>
+    <cs.trilead-ssh2.version>1.0.0-build217</cs.trilead-ssh2.version>
+    <cs.xen-api.version>6.2.0-3.1</cs.xen-api.version>
+    <cs.xml-apis.version>1.4.01</cs.xml-apis.version>
+    <cs.xmlrpc-client.version>3.1.3</cs.xmlrpc-client.version>
+    <cs.xmlrpc-common.version>3.1.3</cs.xmlrpc-common.version>
+    <cs.xstream.version>1.4.7</cs.xstream.version>
+
+    <!-- MySQL is also used in the plugin section -->
+    <cs.mysql.version>5.1.34</cs.mysql.version>
   </properties>
 
   <licenses>
@@ -141,40 +150,28 @@
       <dependency>
         <groupId>org.jacoco</groupId>
         <artifactId>org.jacoco.agent</artifactId>
-        <version>0.7.6.201602180812</version>
+        <version>${cs.org.jacoco.agent.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jacoco</groupId>
         <artifactId>org.jacoco.agent.rt</artifactId>
-        <version>0.7.6.201602180812</version>
+        <version>${cs.org.jacoco.agent.rt.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.4</version>
+        <version>${cs.commons-lang3.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-all</artifactId>
-        <version>${cs.hamcrest.version}</version>
+        <version>${cs.hamcrest-all.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
-        <version>1.10.19</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <artifactId>hamcrest-core</artifactId>
-            <groupId>org.hamcrest</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.12</version>
+        <version>${cs.mockito-all.version}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -186,23 +183,18 @@
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-module-junit4</artifactId>
-        <version>${cs.powermock.version}</version>
+        <version>${cs.powermock-module-junit4.version}</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-mockito</artifactId>
-        <version>${cs.powermock.version}</version>
+        <version>${cs.powermock-api-mockito.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>javax.inject</groupId>
         <artifactId>javax.inject</artifactId>
-        <version>1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mariadb.jdbc</groupId>
-        <artifactId>mariadb-java-client</artifactId>
-        <version>1.4.3</version>
+        <version>${cs.javax.inject.version}</version>
       </dependency>
 
       <!-- go throught these dependencies and evaluate where they should be -->
@@ -215,22 +207,22 @@
       <dependency>
         <groupId>cglib</groupId>
         <artifactId>cglib-nodep</artifactId>
-        <version>${cs.cglib.version}</version>
+        <version>${cs.cglib-nodep.version}</version>
       </dependency>
       <dependency>
         <groupId>net.sf.ehcache</groupId>
         <artifactId>ehcache-core</artifactId>
-        <version>${cs.ehcache.version}</version>
+        <version>${cs.ehcache-core.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>${cs.codec.version}</version>
+        <version>${cs.commons-codec.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-net</groupId>
         <artifactId>commons-net</artifactId>
-        <version>${cs.codec.net}</version>
+        <version>${cs.commons-net.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-validator</groupId>
@@ -240,7 +232,7 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk16</artifactId>
-        <version>${cs.bcprov.version}</version>
+        <version>${cs.bcprov-jdk16.version}</version>
       </dependency>
       <dependency>
         <groupId>com.jcraft</groupId>
@@ -255,17 +247,17 @@
       <dependency>
         <groupId>com.trilead</groupId>
         <artifactId>trilead-ssh2</artifactId>
-        <version>${cs.trilead.version}</version>
+        <version>${cs.trilead-ssh2.version}</version>
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk</artifactId>
-        <version>${cs.aws.sdk.version}</version>
+        <version>${cs.aws-java-sdk.version}</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>
         <artifactId>apache-log4j-extras</artifactId>
-        <version>${cs.log4j.extras.version}</version>
+        <version>${cs.apache-log4j-extras.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>log4j</artifactId>
@@ -276,7 +268,7 @@
       <dependency>
         <groupId>javax.ejb</groupId>
         <artifactId>ejb-api</artifactId>
-        <version>${cs.ejb.version}</version>
+        <version>${cs.ejb-api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.java-ipv6</groupId>
@@ -286,7 +278,7 @@
       <dependency>
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
-        <version>${cs.configuration.version}</version>
+        <version>${cs.commons-configuration.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
@@ -302,12 +294,12 @@
       <dependency>
         <groupId>org.owasp.esapi</groupId>
         <artifactId>esapi</artifactId>
-        <version>2.1.0</version>
+        <version>${cs.esapi.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>javax.persistence</artifactId>
-        <version>${cs.jpa.version}</version>
+        <version>${cs.javax.persistence.version}</version>
       </dependency>
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
@@ -330,16 +322,6 @@
         <version>${cs.guava.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.aspectj</groupId>
-        <artifactId>aspectjtools</artifactId>
-        <version>1.8.4</version>
-      </dependency>
-      <dependency>
-        <groupId>org.aspectj</groupId>
-        <artifactId>aspectjweaver</artifactId>
-        <version>1.8.4</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.axis</groupId>
         <artifactId>axis</artifactId>
         <version>${cs.axis.version}</version>
@@ -347,57 +329,42 @@
       <dependency>
         <groupId>commons-daemon</groupId>
         <artifactId>commons-daemon</artifactId>
-        <version>${cs.daemon.version}</version>
+        <version>${cs.commons-daemon.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.axis</groupId>
         <artifactId>axis-jaxrpc</artifactId>
-        <version>${cs.axis.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>wsdl4j</groupId>
-        <artifactId>wsdl4j</artifactId>
-        <version>1.6.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>1.7.7</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.7</version>
+        <version>${cs.axis-jaxrpc.version}</version>
       </dependency>
       <dependency>
         <groupId>net.java.dev.vcc.thirdparty</groupId>
         <artifactId>xen-api</artifactId>
-        <version>${cs.xapi.version}</version>
+        <version>${cs.xen-api.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.xmlrpc</groupId>
         <artifactId>xmlrpc-client</artifactId>
-        <version>${cs.xmlrpc.version}</version>
+        <version>${cs.xmlrpc-client.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.xmlrpc</groupId>
         <artifactId>xmlrpc-common</artifactId>
-        <version>${cs.xmlrpc.version}</version>
+        <version>${cs.xmlrpc-common.version}</version>
       </dependency>
       <dependency>
         <groupId>org.openqa.selenium.server</groupId>
         <artifactId>selenium-server</artifactId>
-        <version>${cs.selenium.server.version}</version>
+        <version>${cs.selenium-server.version}</version>
       </dependency>
       <dependency>
         <groupId>org.libvirt</groupId>
         <artifactId>libvirt</artifactId>
-        <version>${cs.libvirt-java.version}</version>
+        <version>${cs.libvirt.version}</version>
       </dependency>
       <dependency>
         <groupId>com.ceph</groupId>
         <artifactId>rados</artifactId>
-        <version>${cs.rados-java.version}</version>
+        <version>${cs.rados.version}</version>
       </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION
This PR upgrades Spring 3 to Spring Boot (which uses Spring 4). The side effect of that upgrade is that Java 8 is now possible to be used.

Spring Boot provides dependency management for popular libraries. Dependencies included in the list managed by Spring Boot have been removed from the Cosmic tracking repo dependency management. The only exception being Google GSON, that has been pinned on a version in the 1.x branch due to incompatibility.

Dependencies which had a version pinned in one of the downstream poms have been moved to the tracking repo pom dependency management.

Further  a bit of cleaning, properties now have the name of the artifact and are in lexicographical order.

Integration tests succeeded: https://beta-jenkins.mcc.schubergphilis.com/job/cosmic/job/0002-tracking-repo-branch-build/154/

List of PRs that are needed to be merged with this:
- https://github.com/MissionCriticalCloud/cosmic-agent/pull/6
- https://github.com/MissionCriticalCloud/cosmic-core/pull/187
- https://github.com/MissionCriticalCloud/cosmic-plugin-hypervisor-kvm/pull/31
- https://github.com/MissionCriticalCloud/cosmic-plugin-hypervisor-ovm3/pull/20
- https://github.com/MissionCriticalCloud/cosmic-plugin-hypervisor-xenserver/pull/18
